### PR TITLE
fix(monad): address lint/type errors after FieldType bridge refactor

### DIFF
--- a/monad/src/backend.ts
+++ b/monad/src/backend.ts
@@ -125,7 +125,7 @@ export class GPUBackend {
     if (!this.buffers.heap) {
       throw new Error("Buffers are not initialized")
     }
-    this.device.queue.writeBuffer(this.buffers.heap, 0, heap)
+    this.device.queue.writeBuffer(this.buffers.heap, 0, heap as Uint32Array<ArrayBuffer>)
   }
 
   private createBuffer(data: ArrayBufferView, usage: GPUBufferUsageFlags) {

--- a/monad/src/compiler.ts
+++ b/monad/src/compiler.ts
@@ -1,5 +1,6 @@
 import { OP, TYPE, type CompiledRules } from "./common"
 import { GlobalFieldRegistry, FieldType } from "./context"
+import { fieldTypeToBytecodeType } from "./typeBridge"
 
 // Упрощенные типы для представления конфигурации правил.
 // В реальном проекте они могут быть более сложными и импортироваться из общего пакета.
@@ -226,51 +227,18 @@ export class RulesCompiler {
       
       // Регистрируем поле, если еще не зарегистрировано
       if (!registry.has(name)) {
-        registry.register(name, fieldType, { elementType: typeof typeStr === "string" ? typeStr.match(/^array<(.+)>$/)?.[1] : undefined, enumValues })
+        const elementType = typeof typeStr === "string" ? typeStr.match(/^array<(.+)>$/)?.[1] : undefined
+        const registerOptions = {
+          ...(elementType !== undefined ? { elementType } : {}),
+          ...(enumValues !== undefined ? { enumValues } : {}),
+        }
+        registry.register(name, fieldType, registerOptions)
       }
       
       // Получаем fieldId и сохраняем информацию о поле
       const fieldId = registry.getId(name)
-      // Мост между системами типов: преобразование FieldType (контекст) → TYPE (байткод)
-      //
-      // Исторический контекст:
-      // * FieldType (0=F32, 1=U32, 2=BOOL, 3=STRING_PTR, 4=ARRAY_PTR, 5=SHARED_PTR) — используется в контексте и куче
-      // * TYPE (0=FLOAT, 1=UINT, 2=BOOL, 3=STRING, 4=ARRAY) — используется в байткоде VM
-      //
-      // Маппинг:
-      // - F32 → FLOAT (оба 0) — прямое соответствие
-      // - U32 → UINT (1 → 1) — прямое соответствие  
-      // - BOOL → BOOL (2 → 2) — прямое соответствие
-      // - STRING_PTR → STRING (3 → 3) — указатель в куче → тип строки в VM
-      // - ARRAY_PTR → ARRAY (4 → 4) — указатель в куче → тип массива в VM
-      // - SHARED_PTR → UINT (5 → 1) — SHARED_PTR обрабатывается отдельно в шейдере
-      let typeCode: number
-      switch (fieldType) {
-        case FieldType.F32:
-          typeCode = TYPE.FLOAT  // 0 → 0
-          break
-        case FieldType.U32:
-          typeCode = TYPE.UINT   // 1 → 1
-          break
-        case FieldType.BOOL:
-          typeCode = TYPE.BOOL   // 2 → 2
-          break
-        case FieldType.STRING_PTR:
-          typeCode = TYPE.STRING // 3 → 3 (указатель на строку в куче)
-          break
-        case FieldType.ARRAY_PTR:
-          typeCode = TYPE.ARRAY  // 4 → 4 (указатель на массив в куче)
-          break
-        case FieldType.SHARED_PTR:
-          // SHARED_PTR не имеет прямого соответствия в TYPE
-          // В байткоде SHARED_PTR поля не включаются в условия — они обрабатываются
-          // рекурсивно в шейдере через get_field_value_recursive
-          typeCode = TYPE.UINT   // Запасной вариант
-          break
-        default:
-          typeCode = TYPE.UINT   // Неизвестный тип → UINT
-      }
-      
+      const typeCode = fieldTypeToBytecodeType(fieldType)
+
       this.fields[name] = { fieldId, type: typeCode, subType, enumValues }
     }
   }
@@ -278,32 +246,7 @@ export class RulesCompiler {
   private loadFieldsFromRegistry() {
     const registry = GlobalFieldRegistry.getInstance()
     for (const meta of registry.getAll()) {
-      // Мост между системами типов: преобразование FieldType (контекст) → TYPE (байткод)
-      // Аналогично преобразованию в registerFieldsFromSchema, но для уже зарегистрированных полей
-      let typeCode: number
-      switch (meta.type) {
-        case FieldType.F32:
-          typeCode = TYPE.FLOAT  // 0 → 0
-          break
-        case FieldType.U32:
-          typeCode = TYPE.UINT   // 1 → 1
-          break
-        case FieldType.BOOL:
-          typeCode = TYPE.BOOL   // 2 → 2
-          break
-        case FieldType.STRING_PTR:
-          typeCode = TYPE.STRING // 3 → 3 (указатель на строку в куче)
-          break
-        case FieldType.ARRAY_PTR:
-          typeCode = TYPE.ARRAY  // 4 → 4 (указатель на массив в куче)
-          break
-        case FieldType.SHARED_PTR:
-          // SHARED_PTR не используется напрямую в условиях байткода
-          typeCode = TYPE.UINT   // Запасной вариант
-          break
-        default:
-          typeCode = TYPE.UINT   // Неизвестный тип → UINT
-      }
+      const typeCode = fieldTypeToBytecodeType(meta.type)
 
       let subType: number | undefined
       switch (meta.elementType) {

--- a/monad/src/context/GlobalFieldRegistry.ts
+++ b/monad/src/context/GlobalFieldRegistry.ts
@@ -120,7 +120,13 @@ export class GlobalFieldRegistry {
     }
 
     const fieldId = this.nextId++
-    const meta: FieldMeta = { fieldId, type, name, elementType: options.elementType, enumValues: options.enumValues }
+    const meta: FieldMeta = {
+      fieldId,
+      type,
+      name,
+      ...(options.elementType !== undefined ? { elementType: options.elementType } : {}),
+      ...(options.enumValues !== undefined ? { enumValues: options.enumValues } : {}),
+    }
     this.nameToMeta.set(name, meta)
     this.idToMeta.set(fieldId, meta)
     return fieldId

--- a/monad/src/index.ts
+++ b/monad/src/index.ts
@@ -189,7 +189,11 @@ export class MonadSystem {
           }
       }
       if (!registry.has(name)) {
-        registry.register(name, fieldType, { elementType, enumValues })
+        const registerOptions = {
+          ...(elementType !== undefined ? { elementType } : {}),
+          ...(enumValues !== undefined ? { enumValues } : {}),
+        }
+        registry.register(name, fieldType, registerOptions)
       }
     }
 

--- a/monad/src/typeBridge.ts
+++ b/monad/src/typeBridge.ts
@@ -1,0 +1,34 @@
+import { TYPE } from "./common"
+import { FieldType, type FieldTypeValue } from "./context"
+
+/**
+ * Мост совместимости между новой системой типов контекста (FieldType)
+ * и legacy-системой типов байткода/шейдера (TYPE).
+ *
+ * Почему нужен маппинг:
+ * - FieldType используется в самописываемом контексте + глобальной куче.
+ * - TYPE зафиксирован в формате байткода и в WGSL classify-шейдере.
+ *
+ * Особый случай:
+ * - SHARED_PTR не имеет прямого аналога в TYPE.
+ * - Для обратной совместимости кодируется как UINT (fallback),
+ *   а фактическое чтение таких полей делается рекурсивно в шейдере.
+ */
+export function fieldTypeToBytecodeType(fieldType: FieldTypeValue): number {
+  switch (fieldType) {
+    case FieldType.F32:
+      return TYPE.FLOAT
+    case FieldType.U32:
+      return TYPE.UINT
+    case FieldType.BOOL:
+      return TYPE.BOOL
+    case FieldType.STRING_PTR:
+      return TYPE.STRING
+    case FieldType.ARRAY_PTR:
+      return TYPE.ARRAY
+    case FieldType.SHARED_PTR:
+      return TYPE.UINT
+    default:
+      return TYPE.UINT
+  }
+}

--- a/monad/tests/typeBridge.test.ts
+++ b/monad/tests/typeBridge.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { TYPE } from "../src/common"
+import { FieldType } from "../src/context"
+import { fieldTypeToBytecodeType } from "../src/typeBridge"
+
+describe("fieldTypeToBytecodeType", () => {
+  test("маппит прямые соответствия FieldType -> TYPE", () => {
+    expect(fieldTypeToBytecodeType(FieldType.F32)).toBe(TYPE.FLOAT)
+    expect(fieldTypeToBytecodeType(FieldType.U32)).toBe(TYPE.UINT)
+    expect(fieldTypeToBytecodeType(FieldType.BOOL)).toBe(TYPE.BOOL)
+    expect(fieldTypeToBytecodeType(FieldType.STRING_PTR)).toBe(TYPE.STRING)
+    expect(fieldTypeToBytecodeType(FieldType.ARRAY_PTR)).toBe(TYPE.ARRAY)
+  })
+
+  test("маппит SHARED_PTR в TYPE.UINT как fallback совместимости", () => {
+    expect(fieldTypeToBytecodeType(FieldType.SHARED_PTR)).toBe(TYPE.UINT)
+  })
+})


### PR DESCRIPTION
### Motivation
- Centralized FieldType→TYPE mapping introduced stricter TypeScript checks (`exactOptionalPropertyTypes`) and revealed a WebGPU buffer write signature mismatch that broke typechecking.

### Description
- Add a compatibility bridge `fieldTypeToBytecodeType` in `monad/src/typeBridge.ts` and replace duplicated switch logic in `monad/src/compiler.ts` with calls to `fieldTypeToBytecodeType`.
- Fix `GlobalFieldRegistry.register` to include `elementType` and `enumValues` in `FieldMeta` only when defined to satisfy exact-optional-property typing.
- Update call sites in `monad/src/compiler.ts` and `monad/src/index.ts` to build `registerOptions` conditionally and pass only defined optional fields to `registry.register`.
- Fix WebGPU `writeBuffer` signature in `monad/src/backend.ts` by casting the heap argument to the expected view type.
- Add `monad/tests/typeBridge.test.ts` that validates the `fieldTypeToBytecodeType` mappings (including `SHARED_PTR -> TYPE.UINT` fallback).

### Testing
- Typecheck run with `bunx tsc -p monad/tsconfig.json --noEmit` completed successfully.
- Unit tests run with `bun test monad/tests/typeBridge.test.ts` passed (`2 passed, 0 failed`).
- Compiler functional suite run with `bun test monad/tests/compiler.functional.test.ts` passed (`26 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a803b2c3483309d8eb79099ae6a0c)