### PR TITLE
boundary: enable skipped enum/array tests and implement enum/array encoding + WGSL length checks

### DIFF
--- a/boundary/src/compiler.ts
+++ b/boundary/src/compiler.ts
@@ -330,7 +330,7 @@ export class RulesCompiler {
             const encoded = this.encodeValue(
               field.type,
               v,
-              field as { subType?: number | undefined; enumValues?: any[] | undefined } | undefined,
+              this.getEncodingContextForOp(field, check.op),
             )
             console.log(`[Compiler]   List item: "${v}" -> encoded=${encoded}`)
             blockHeap.push(encoded)
@@ -341,7 +341,7 @@ export class RulesCompiler {
             this.encodeValue(
               field.type,
               check.val,
-              field as { subType?: number | undefined; enumValues?: any[] | undefined } | undefined,
+              this.getEncodingContextForOp(field, check.op),
             ),
           )
         }
@@ -397,7 +397,32 @@ export class RulesCompiler {
           checks.push({ op: OP.NOT_INCLUDE, val: v })
           break
         case "length":
-          checks.push({ op: OP.LENGTH, val: v })
+          if (typeof v === "number") {
+            checks.push({ op: OP.LENGTH, val: v })
+            break
+          }
+
+          if (typeof v === "object" && v !== null) {
+            for (const [lengthOp, lengthVal] of Object.entries(v)) {
+              switch (lengthOp) {
+                case "eq":
+                  checks.push({ op: OP.LENGTH, val: lengthVal })
+                  break
+                case "gt":
+                  checks.push({ op: OP.GT, val: lengthVal })
+                  break
+                case "lt":
+                  checks.push({ op: OP.LT, val: lengthVal })
+                  break
+                case "gte":
+                  checks.push({ op: OP.GTE, val: lengthVal })
+                  break
+                case "lte":
+                  checks.push({ op: OP.LTE, val: lengthVal })
+                  break
+              }
+            }
+          }
           break
         case "isEmpty":
           checks.push({ op: OP.IS_EMPTY, val: v })
@@ -425,6 +450,22 @@ export class RulesCompiler {
       }
     }
     return checks
+  }
+
+  private getEncodingContextForOp(
+    field: { type: number; subType?: number | undefined; enumValues?: any[] | undefined },
+    op: number,
+  ): { subType?: number | undefined; enumValues?: any[] | undefined } | undefined {
+    // Для массивов include/notInclude значение нужно кодировать в тип элемента.
+    if (field.type === TYPE.ARRAY) {
+      if (op === OP.INCLUDE || op === OP.NOT_INCLUDE) {
+        return field
+      }
+      // Для length/isEmpty и скалярных сравнений по длине используем чисто UINT/BOOL.
+      return undefined
+    }
+
+    return field
   }
 
   private encodeValue(

--- a/boundary/src/context/BraneBuilder.ts
+++ b/boundary/src/context/BraneBuilder.ts
@@ -220,7 +220,17 @@ export class BraneBuilder {
           dataView.setFloat32(offsetBytes, Number(layout.value), true)
           break
         case FieldType.U32:
-          dataView.setUint32(offsetBytes, Number(layout.value), true)
+          if (Array.isArray(layout.meta.enumValues)) {
+            const enumIndex = layout.meta.enumValues.indexOf(layout.value)
+            if (enumIndex === -1) {
+              throw new Error(
+                `Значение '${String(layout.value)}' не найдено в enum '${layout.name}': [${layout.meta.enumValues.join(", ")}]`,
+              )
+            }
+            dataView.setUint32(offsetBytes, enumIndex, true)
+          } else {
+            dataView.setUint32(offsetBytes, Number(layout.value), true)
+          }
           break
         case FieldType.BOOL:
           dataView.setUint32(offsetBytes, layout.value ? 1 : 0, true)
@@ -269,7 +279,9 @@ export class BraneBuilder {
             } else if (elementType === "integer" || elementType === "boolean") {
               arrayView[i + 1] = Number(item)
             } else if (elementType === "string") {
-              throw new Error(`Массивы строк пока не поддерживаются для поля '${layout.name}'`)
+              const atlas = getStringAtlas()
+              const stringId = atlas.intern(String(item))
+              arrayView[i + 1] = stringId
             } else {
               arrayView[i + 1] = Number(item)
             }

--- a/boundary/src/context/BraneManager.ts
+++ b/boundary/src/context/BraneManager.ts
@@ -314,6 +314,18 @@ export class BraneManager {
         break
       }
       case FieldType.U32:
+        if (Array.isArray(fieldMeta.enumValues)) {
+          const enumIndex = fieldMeta.enumValues.indexOf(newValue)
+          if (enumIndex === -1) {
+            throw new Error(
+              `Значение '${String(newValue)}' не найдено в enum '${componentName}': [${fieldMeta.enumValues.join(", ")}]`,
+            )
+          }
+          this.heapData[absoluteOffset] = enumIndex
+        } else {
+          this.heapData[absoluteOffset] = Number(newValue)
+        }
+        break
       case FieldType.BOOL:
         this.heapData[absoluteOffset] = Number(newValue)
         break
@@ -370,7 +382,9 @@ export class BraneManager {
           } else if (elementType === "integer" || elementType === "boolean") {
             arrayView[i + 1] = Number(item)
           } else if (elementType === "string") {
-            throw new Error(`Массивы строк пока не поддерживаются для компоненты '${componentName}'`)
+            const atlas = getStringAtlas()
+            const stringId = atlas.intern(String(item))
+            arrayView[i + 1] = stringId
           } else {
             arrayView[i + 1] = Number(item)
           }

--- a/boundary/src/evolution.wgsl
+++ b/boundary/src/evolution.wgsl
@@ -301,6 +301,30 @@ fn get_field_value_raw(field_index: u32, target_field_id: u32) -> u32 {
  * @returns true если условие выполнено
  */
 fn check_cond(op: u32, field_type: u32, val_a_raw: u32, val_b_raw: u32, cond_values_base: u32) -> bool {
+  // Для ARRAY поддерживаем скалярные сравнения по длине.
+  // op: EQ/NEQ/GT/LT/GTE/LTE, val_b_raw: ожидаемая длина.
+  if (field_type == 4u && op <= 5u) {
+    let heap_ptr = val_a_raw;
+    let len = select(0u, heap[heap_ptr], heap_ptr != 0u);
+
+    if (op == 0u) {
+      return len == val_b_raw;
+    }
+    if (op == 1u) {
+      return len != val_b_raw;
+    }
+    if (op == 2u) {
+      return len > val_b_raw;
+    }
+    if (op == 3u) {
+      return len < val_b_raw;
+    }
+    if (op == 4u) {
+      return len >= val_b_raw;
+    }
+    return len <= val_b_raw;
+  }
+
   // Строковые операции (TYPE.STRING = 3)
   if (field_type == 3u) {
     // EQ / NEQ для строк

--- a/boundary/tests/types/array.test.ts
+++ b/boundary/tests/types/array.test.ts
@@ -10,7 +10,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
   // Поддерживаемые типы элементов: array<string>, array<number>
 
   describe("Оператор INCLUDE (содержит элемент)", () => {
-    test.skip("должен перейти если массив содержит указанный элемент (number)", async () => {
+    test("должен перейти если массив содержит указанный элемент (number)", async () => {
       // SKIP: Требует полной реализации оператора INCLUDE в WGSL
       const superposition = {
         IDLE: { ACTIVE: { tags: { include: 5 } } },
@@ -32,7 +32,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
       expect(result.states![2]).toBe("IDLE") // 5 not in []
     })
 
-    test.skip("должен перейти если массив содержит указанный элемент (string)", async () => {
+    test("должен перейти если массив содержит указанный элемент (string)", async () => {
       // SKIP: Требует полной реализации оператора INCLUDE в WGSL + интернирование строк
       const superposition = {
         IDLE: { ACTIVE: { tags: { include: "fire" } } },
@@ -54,7 +54,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
   })
 
   describe("Оператор NOT_INCLUDE (не содержит элемент)", () => {
-    test.skip("должен перейти если массив не содержит указанный элемент", async () => {
+    test("должен перейти если массив не содержит указанный элемент", async () => {
       // SKIP: Требует полной реализации оператора NOT_INCLUDE в WGSL
       const superposition = {
         IDLE: { ACTIVE: { tags: { notInclude: 99 } } },
@@ -78,7 +78,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
   })
 
   describe("Оператор LENGTH (длина массива)", () => {
-    test.skip("должен перейти при равенстве длины указанному значению", async () => {
+    test("должен перейти при равенстве длины указанному значению", async () => {
       // SKIP: Требует полной реализации оператора LENGTH в WGSL
       const superposition = {
         IDLE: { ACTIVE: { items: { length: 3 } } },
@@ -102,7 +102,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
       expect(result.states![3]).toBe("IDLE") // length == 0
     })
 
-    test.skip("должен поддерживать сравнение длины с операторами", async () => {
+    test("должен поддерживать сравнение длины с операторами", async () => {
       // SKIP: Требует реализации расширенного синтаксиса для length
       const superposition = {
         IDLE: { ACTIVE: { items: { length: { gte: 2 } } } },
@@ -126,7 +126,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
   })
 
   describe("Оператор IS_EMPTY (пустой массив)", () => {
-    test.skip("должен перейти если массив пуст", async () => {
+    test("должен перейти если массив пуст", async () => {
       // SKIP: Требует полной реализации оператора IS_EMPTY в WGSL
       const superposition = {
         IDLE: { EMPTY: { items: { isEmpty: true } } },
@@ -148,7 +148,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
       expect(result.states![2]).toBe("IDLE") // [1, 2, 3] is not empty
     })
 
-    test.skip("должен перейти если массив не пуст (isEmpty: false)", async () => {
+    test("должен перейти если массив не пуст (isEmpty: false)", async () => {
       // SKIP: Требует полной реализации оператора IS_EMPTY в WGSL
       const superposition = {
         IDLE: { ACTIVE: { items: { isEmpty: false } } },
@@ -172,7 +172,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
   })
 
   describe("Комбинированные условия с массивами", () => {
-    test.skip("должен перейти при выполнении нескольких условий", async () => {
+    test("должен перейти при выполнении нескольких условий", async () => {
       // SKIP: Требует полной реализации операторов массива
       const superposition = {
         IDLE: {
@@ -216,7 +216,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
   })
 
   describe("Граничные случаи", () => {
-    test.skip("должен корректно обрабатывать пустой массив", async () => {
+    test("должен корректно обрабатывать пустой массив", async () => {
       // SKIP: Требует полной реализации операторов массива
       const superposition = {
         IDLE: { ACTIVE: { items: { isEmpty: true } } },
@@ -232,7 +232,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
       expect(result.states![0]).toBe("ACTIVE")
     })
 
-    test.skip("должен корректно обрабатывать массив с одним элементом", async () => {
+    test("должен корректно обрабатывать массив с одним элементом", async () => {
       // SKIP: Требует полной реализации операторов массива
       const superposition = {
         IDLE: { ACTIVE: { items: { length: 1 } } },
@@ -248,7 +248,7 @@ describe("Boundary — Тип ARRAY (array)", () => {
       expect(result.states![0]).toBe("ACTIVE")
     })
 
-    test.skip("должен корректно обрабатывать большой массив", async () => {
+    test("должен корректно обрабатывать большой массив", async () => {
       // SKIP: Требует полной реализации операторов массива
       const superposition = {
         IDLE: { ACTIVE: { items: { length: 100 } } },

--- a/boundary/tests/types/uint.test.ts
+++ b/boundary/tests/types/uint.test.ts
@@ -11,7 +11,7 @@ describe("Boundary — Тип UINT (enum)", () => {
   // Текущая реализация enum имеет особенности, которые требуют дополнительного исследования.
 
   describe("Оператор EQ (равно)", () => {
-    test.skip("должен перейти при значении равном указанному (string enum)", async () => {
+    test("должен перейти при значении равном указанному (string enum)", async () => {
       // SKIP: Требует проверки реализации enum<string>
       const superposition = {
         IDLE: { ACTIVE: { status: { eq: "ACTIVE" } } },
@@ -35,7 +35,7 @@ describe("Boundary — Тип UINT (enum)", () => {
       expect(result.states![2]).toBe("IDLE") // DEAD != ACTIVE
     })
 
-    test.skip("должен перейти при значении равном указанному (number enum)", async () => {
+    test("должен перейти при значении равном указанному (number enum)", async () => {
       // SKIP: Требует проверки реализации enum<number>
       const superposition = {
         IDLE: { ACTIVE: { level: { eq: 2 } } },
@@ -61,7 +61,7 @@ describe("Boundary — Тип UINT (enum)", () => {
   })
 
   describe("Оператор NEQ (не равно)", () => {
-    test.skip("должен перейти при значении не равном указанному", async () => {
+    test("должен перейти при значении не равном указанному", async () => {
       // SKIP: Требует проверки реализации NEQ для enum
       const superposition = {
         IDLE: { ACTIVE: { status: { neq: "IDLE" } } },
@@ -87,7 +87,7 @@ describe("Boundary — Тип UINT (enum)", () => {
   })
 
   describe("Оператор GT (больше)", () => {
-    test.skip("должен перейти при значении больше указанного", async () => {
+    test("должен перейти при значении больше указанного", async () => {
       // SKIP: Требует проверки реализации GT для enum
       const superposition = {
         IDLE: { ACTIVE: { level: { gt: 1 } } },
@@ -113,7 +113,7 @@ describe("Boundary — Тип UINT (enum)", () => {
   })
 
   describe("Оператор LT (меньше)", () => {
-    test.skip("должен перейти при значении меньше указанного", async () => {
+    test("должен перейти при значении меньше указанного", async () => {
       // SKIP: Требует проверки реализации LT для enum
       const superposition = {
         IDLE: { ACTIVE: { level: { lt: 3 } } },
@@ -139,7 +139,7 @@ describe("Boundary — Тип UINT (enum)", () => {
   })
 
   describe("Оператор GTE (больше или равно)", () => {
-    test.skip("должен перейти при значении больше или равном указанному", async () => {
+    test("должен перейти при значении больше или равном указанному", async () => {
       // SKIP: Требует проверки реализации GTE для enum
       const superposition = {
         IDLE: { ACTIVE: { level: { gte: 3 } } },
@@ -165,7 +165,7 @@ describe("Boundary — Тип UINT (enum)", () => {
   })
 
   describe("Оператор LTE (меньше или равно)", () => {
-    test.skip("должен перейти при значении меньше или равном указанному", async () => {
+    test("должен перейти при значении меньше или равном указанному", async () => {
       // SKIP: Требует проверки реализации LTE для enum
       const superposition = {
         IDLE: { ACTIVE: { level: { lte: 2 } } },
@@ -191,7 +191,7 @@ describe("Boundary — Тип UINT (enum)", () => {
   })
 
   describe("Оператор IN (входит в список)", () => {
-    test.skip("должен перейти если значение входит в список", async () => {
+    test("должен перейти если значение входит в список", async () => {
       // SKIP: Требует проверки реализации IN для enum
       const superposition = {
         IDLE: { ACTIVE: { status: { in: ["ACTIVE", "RUNNING"] } } },
@@ -219,7 +219,7 @@ describe("Boundary — Тип UINT (enum)", () => {
   })
 
   describe("Оператор NOT_IN (не входит в список)", () => {
-    test.skip("должен перейти если значение не входит в список", async () => {
+    test("должен перейти если значение не входит в список", async () => {
       // SKIP: Требует проверки реализации NOT_IN для enum
       const superposition = {
         IDLE: { ACTIVE: { status: { notIn: ["IDLE", "DEAD"] } } },
@@ -247,7 +247,7 @@ describe("Boundary — Тип UINT (enum)", () => {
   })
 
   describe("Множественные условия", () => {
-    test.skip("должен перейти при выполнении условий", async () => {
+    test("должен перейти при выполнении условий", async () => {
       // SKIP: Требует проверки реализации множественных условий для enum
       const superposition = {
         IDLE: { ACTIVE: { level: { gte: 2, lte: 4 } } },


### PR DESCRIPTION
### Motivation

- Previously many `uint` (enum) and `array` tests were marked `skip` because runtime/compiler handling for enums and array operators was incomplete; the goal is to make those tests executable and correct.
- Enums must be encoded as indices (not raw values) in runtime brane data so comparators and IN/NOT_IN work consistently with compiler constant folding.
- Array operators (`include`, `length`, `isEmpty`) require proper value encoding and GPU-side evaluation (including length comparisons) to pass behavioral tests.

### Description

- Enabled formerly skipped tests by replacing `test.skip` with `test` in `boundary/tests/types/uint.test.ts` and `boundary/tests/types/array.test.ts` so they run in CI/local runs.
- Compiler updates in `boundary/src/compiler.ts`: added `getEncodingContextForOp` to select proper encoding context for array ops, made `encodeValue` use that context, and extended `parseCondition` to accept `length: { eq|gt|lt|gte|lte }` forms.
- Runtime updates: `BraneBuilder` now encodes `U32` enum field initial values as enum indices and supports `array<string>` element interning via `StringAtlas`; `BraneManager` update logic similarly accepts enum value updates (stores index) and supports updating string arrays by storing interned string IDs.
- WGSL runtime (`boundary/src/evolution.wgsl`) extended `check_cond` to support scalar comparison operators (`EQ/NEQ/GT/LT/GTE/LTE`) applied to `TYPE.ARRAY` by comparing the array length, enabling `length` and `isEmpty` semantics on GPU.

### Testing

- Ran dependency install and tests: executed `bun install` then `bun test boundary/tests/types` and earlier targeted runs `bun test boundary/tests/types/uint.test.ts boundary/tests/types/array.test.ts` to iterate during development, and all affected tests passed.
- Final test run: `bun test boundary/tests/types` — 64 tests passed, 0 failed (summary shown in test runner output).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69936cf07eb48327aba3038f2bd3beb6)