### PR TITLE
Improve create-metafor self-update flow and stale npx cache handling

### DIFF
--- a/create-metafor/README.md
+++ b/create-metafor/README.md
@@ -28,6 +28,7 @@ Creates a Meta with basic error handling template.
 | `-d, --desc <desc>` | Meta description | `"MetaFor {name}"` |
 | `--dir <dir>` | Output directory | `.` |
 | `-l, --lang <lang>` | Output language (ru\|en) | auto-detect |
+| `--self-update` | Force self-update + clear npx cache | - |
 
 ## Examples
 
@@ -43,6 +44,17 @@ bun create metafor git-commit -d "Commit"
 
 # Force English language
 bun create metafor auth -l en
+```
+
+
+## Updates
+
+```bash
+# Recommended run to avoid stale npx cache
+npx --yes create-metafor@latest my-meta
+
+# Explicitly update installed binary
+create-metafor --self-update
 ```
 
 ## Generated Structure

--- a/create-metafor/README.ru.md
+++ b/create-metafor/README.ru.md
@@ -28,6 +28,7 @@ bun create metafor auth
 | `-d, --desc <desc>` | Описание Мета | `"MetaFor {name}"` |
 | `--dir <dir>` | Директория для создания | `.` |
 | `-l, --lang <lang>` | Язык вывода (ru\|en) | автодетект |
+| `--self-update` | Принудительное самообновление + очистка кеша npx | - |
 
 ## Примеры
 
@@ -43,6 +44,17 @@ bun create metafor git-commit -d "Коммит"
 
 # Принудительно английский язык
 bun create metafor auth -l en
+```
+
+
+## Обновление
+
+```bash
+# Рекомендуемый запуск без застревания на кеше npx
+npx --yes create-metafor@latest my-meta
+
+# Явно обновить установленную версию
+create-metafor --self-update
 ```
 
 ## Структура

--- a/create-metafor/src/cli.ts
+++ b/create-metafor/src/cli.ts
@@ -21,10 +21,25 @@ import {
   gitAddAll,
   gitCommit,
 } from "./git.ts"
+import { runSelfUpdate } from "./update.ts"
 
 async function main() {
   // Парсинг аргументов
   const args = process.argv.slice(2)
+
+  if (args.includes("--self-update") || args.includes("--update")) {
+    console.log("\n🔄 Обновляю create-metafor до последней версии...\n")
+    const result = await runSelfUpdate()
+
+    if (result.ok) {
+      console.log("\n✅ create-metafor обновлен. Кеш npx очищен.\n")
+      process.exit(0)
+    }
+
+    console.error(`\n❌ Не удалось обновить: ${result.error}\n`)
+    console.error(`Попробуйте вручную: ${result.command.label}\n`)
+    process.exit(1)
+  }
 
   // Если нет аргументов и есть интерактивный терминал — запускаем TUI
   if (args.length === 0 && process.stdin.isTTY) {
@@ -78,6 +93,7 @@ ${t.helpOptions}
   -d, --desc <desc>    ${t.optionDesc}
   --dir <dir>          ${t.optionDir} (${t.defaultDesc}: .)
   -l, --lang <lang>    ${t.optionLang}
+  --self-update        self update create-metafor
 
 ${t.helpExamples}
   ${runner} create metafor my-feature
@@ -107,6 +123,7 @@ ${t.helpOptions}
   -d, --desc <desc>    ${t.optionDesc}
   --dir <dir>          ${t.optionDir} (${t.defaultDesc}: .)
   -l, --lang <lang>    ${t.optionLang}
+  --self-update        self update create-metafor
 
 ${t.helpExamples}
   ${runner} create metafor my-feature

--- a/create-metafor/src/tui/components/Form.tsx
+++ b/create-metafor/src/tui/components/Form.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from "react"
 import { Box, Text, useInput, useApp } from "ink"
-import { spawn } from "child_process"
-import os from "os"
 import {
   Header,
   InputField,
@@ -14,6 +12,7 @@ import {
 import { useCursor, useScreenSize, useCleanup, useVersionCheck } from "../hooks"
 import type { Field, View, MenuItem } from "../types"
 import packageJson from "../../../package.json"
+import { runSelfUpdate } from "../../update"
 
 interface Props {
   onSubmit: (name: string, description: string, dir: string) => void
@@ -100,30 +99,15 @@ export default function Form({ onSubmit }: Props) {
         if (selectedButton === "update") {
           setIsUpdating(true)
           setShowUpdateModal(false)
-          // Запускаем обновление
-          setIsUpdating(true)
-          setShowUpdateModal(false)
 
-          const child = spawn("npm", ["install", "-g", "create-metafor@latest"], {
-            stdio: "pipe",
-          })
-
-          child.on("error", (err: any) => {
+          runSelfUpdate().then((result) => {
             setIsUpdating(false)
-            setUpdateError(`Не удалось запустить npm: ${err.message}. Установите npm или обновите вручную: npm install -g create-metafor@latest`)
-            setShowUpdateModal(true)
-          })
-
-          child.on("close", (code: number) => {
-            setIsUpdating(false)
-            if (code === 0) {
-              // Успешно обновлено
-              setUpdateError(null) // очистим, если было
-              // Выводим сообщение и выходим
-              console.log("\n✅ Обновление выполнено! Пожалуйста, запустите команду снова.\n")
+            if (result.ok) {
+              setUpdateError(null)
+              console.log("\n✅ Обновление выполнено. Кеш npx очищен, перезапустите команду.\n")
               process.exit(0)
             } else {
-              setUpdateError(`Не удалось обновить (код ${code}). Попробуйте вручную: npm install -g create-metafor@latest`)
+              setUpdateError(`Не удалось обновить (${result.error}). Попробуйте вручную: ${result.command.label}`)
               setShowUpdateModal(true)
             }
           })

--- a/create-metafor/src/tui/hooks/useVersionCheck.ts
+++ b/create-metafor/src/tui/hooks/useVersionCheck.ts
@@ -1,10 +1,35 @@
 import { useState, useEffect } from "react"
 import { Worker } from "worker_threads"
+import { existsSync } from "fs"
 import { fileURLToPath } from "url"
-import { dirname, join } from "path"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+function toParts(version: string) {
+  return version.replace(/^v/, "").split(".").map((part) => Number(part) || 0)
+}
+
+function isNewerVersion(latest: string, current: string) {
+  const a = toParts(latest)
+  const b = toParts(current)
+  const length = Math.max(a.length, b.length)
+
+  for (let i = 0; i < length; i++) {
+    const left = a[i] || 0
+    const right = b[i] || 0
+    if (left > right) return true
+    if (left < right) return false
+  }
+
+  return false
+}
+
+function resolveWorkerPath() {
+  const jsWorker = new URL("../workers/version-checker.js", import.meta.url)
+  if (existsSync(fileURLToPath(jsWorker))) {
+    return fileURLToPath(jsWorker)
+  }
+
+  return fileURLToPath(new URL("../workers/version-checker.ts", import.meta.url))
+}
 
 export function useVersionCheck(currentVersion: string, skipCheck = false) {
   const [latestVersion, setLatestVersion] = useState<string | null>(null)
@@ -17,19 +42,20 @@ export function useVersionCheck(currentVersion: string, skipCheck = false) {
       return
     }
 
-    const workerPath = join(__dirname, "workers", "version-checker.js")
-    const worker = new Worker(workerPath)
+    const worker = new Worker(resolveWorkerPath())
 
     worker.on("message", (msg: any) => {
       if (msg.type === "latest") {
         setLatestVersion(msg.version)
         setIsLoading(false)
-        if (msg.version !== currentVersion) {
-          setHasUpdate(true)
-        }
+        setHasUpdate(isNewerVersion(msg.version, currentVersion))
       } else if (msg.type === "error") {
         setIsLoading(false)
       }
+    })
+
+    worker.on("error", () => {
+      setIsLoading(false)
     })
 
     return () => {

--- a/create-metafor/src/tui/workers/version-checker.ts
+++ b/create-metafor/src/tui/workers/version-checker.ts
@@ -1,12 +1,27 @@
 import { parentPort } from "worker_threads"
 
 async function checkLatestVersion() {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 4000)
+
   try {
-    const response = await fetch("https://registry.npmjs.org/create-metafor/latest")
+    const response = await fetch("https://registry.npmjs.org/create-metafor/latest", {
+      headers: {
+        "cache-control": "no-cache",
+      },
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`npm registry responded with ${response.status}`)
+    }
+
     const data: any = await response.json()
     parentPort?.postMessage({ type: "latest", version: data.version })
   } catch (error: any) {
     parentPort?.postMessage({ type: "error", error: error.message })
+  } finally {
+    clearTimeout(timeout)
   }
 }
 

--- a/create-metafor/src/update.ts
+++ b/create-metafor/src/update.ts
@@ -1,0 +1,84 @@
+import { spawn } from "child_process"
+import { existsSync, rmSync } from "fs"
+import os from "os"
+import { join } from "path"
+
+const PACKAGE_NAME = "create-metafor"
+
+export interface UpdateCommand {
+  command: string
+  args: string[]
+  label: string
+}
+
+export function getSelfUpdateCommand(userAgent = process.env.npm_config_user_agent || ""): UpdateCommand {
+  const ua = userAgent.toLowerCase()
+
+  if (ua.includes("bun/")) {
+    return {
+      command: "bun",
+      args: ["add", "-g", `${PACKAGE_NAME}@latest`],
+      label: "bun add -g create-metafor@latest",
+    }
+  }
+
+  if (ua.includes("pnpm/")) {
+    return {
+      command: "pnpm",
+      args: ["add", "-g", `${PACKAGE_NAME}@latest`],
+      label: "pnpm add -g create-metafor@latest",
+    }
+  }
+
+  return {
+    command: "npm",
+    args: ["install", "-g", `${PACKAGE_NAME}@latest`, "--force"],
+    label: "npm install -g create-metafor@latest --force",
+  }
+}
+
+function cleanupNpxCache() {
+  const home = os.homedir()
+  const candidates = [
+    join(home, ".npm", "_npx"),
+    join(home, ".cache", "npm", "_npx"),
+  ]
+
+  for (const path of candidates) {
+    if (existsSync(path)) {
+      rmSync(path, { recursive: true, force: true })
+    }
+  }
+}
+
+export async function runSelfUpdate(): Promise<{ ok: boolean, error?: string, command: UpdateCommand }> {
+  const updateCommand = getSelfUpdateCommand()
+
+  return new Promise((resolve) => {
+    const child = spawn(updateCommand.command, updateCommand.args, {
+      stdio: "inherit",
+    })
+
+    child.on("error", (error: Error) => {
+      resolve({
+        ok: false,
+        error: error.message,
+        command: updateCommand,
+      })
+    })
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        cleanupNpxCache()
+        resolve({ ok: true, command: updateCommand })
+        return
+      }
+
+      resolve({
+        ok: false,
+        error: `exit code ${code}`,
+        command: updateCommand,
+      })
+    })
+  })
+}

--- a/create-metafor/tests/update.test.ts
+++ b/create-metafor/tests/update.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { getSelfUpdateCommand } from "../src/update"
+
+describe("getSelfUpdateCommand", () => {
+  test("uses bun for bun user agent", () => {
+    const result = getSelfUpdateCommand("bun/1.2.0")
+    expect(result.command).toBe("bun")
+    expect(result.args.join(" ")).toContain("add -g create-metafor@latest")
+  })
+
+  test("uses pnpm for pnpm user agent", () => {
+    const result = getSelfUpdateCommand("pnpm/9.0.0 npm/? node/v20")
+    expect(result.command).toBe("pnpm")
+  })
+
+  test("falls back to npm and force update", () => {
+    const result = getSelfUpdateCommand("npm/10.0.0")
+    expect(result.command).toBe("npm")
+    expect(result.args).toContain("--force")
+  })
+})


### PR DESCRIPTION
### Motivation
- Ensure reliable self-updates for the TUI by addressing differences between `npm`, `npx`, `bun` and `pnpm` installs to avoid running stale versions from cache. 
- Provide an explicit, on-demand update path so users can upgrade the installed binary without manual copy/paste of commands. 
- Reduce false positives and hangs in the background version check by making the check more robust and environment-aware.

### Description
- Add a dedicated updater module `src/update.ts` that exposes `getSelfUpdateCommand` and `runSelfUpdate`, selecting the appropriate package-manager command (bun/pnpm/npm) and clearing common `npx` cache folders after a successful update. 
- Wire CLI flags `--self-update` / `--update` to call `runSelfUpdate` and print clear success/failure messages and a fallback manual command label. 
- Replace the TUI's direct `npm install -g` invocation with `runSelfUpdate()` in the update modal and surface actionable error text when update fails. 
- Improve version check logic in `useVersionCheck`: numeric semver-like comparison, worker path resolution for `src` vs `dist`, worker error handling; and make the worker fetch use a timeout and `cache-control: no-cache`. 
- Update `README.md` and `README.ru.md` with recommended update patterns (including `npx --yes create-metafor@latest`) and add `create-metafor/tests/update.test.ts` to validate package-manager command selection.

### Testing
- Ran `bun test` in `create-metafor` and all tests passed, including the new updater tests (`24` tests passed). 
- Attempted `bun run build` but it fails in this environment due to an unresolved linked dependency `@metafor/build`, which is an external/infrastructure setup issue and not caused by the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989c98db0c83308770525573e6302c)