### PR TITLE
Fix TUI update modal behavior and restart flow in create-metafor

### DIFF
--- a/create-metafor/README.md
+++ b/create-metafor/README.md
@@ -28,6 +28,7 @@ Creates a Meta with basic error handling template.
 | `-d, --desc <desc>` | Meta description | `"MetaFor {name}"` |
 | `--dir <dir>` | Output directory | `.` |
 | `-l, --lang <lang>` | Output language (ru\|en) | auto-detect |
+| `--self-update` | Force self-update + clear npx cache | - |
 
 ## Examples
 
@@ -43,6 +44,17 @@ bun create metafor git-commit -d "Commit"
 
 # Force English language
 bun create metafor auth -l en
+```
+
+
+## Updates
+
+```bash
+# Recommended run to avoid stale npx cache
+npx --yes create-metafor@latest my-meta
+
+# Explicitly update installed binary
+create-metafor --self-update
 ```
 
 ## Generated Structure

--- a/create-metafor/README.ru.md
+++ b/create-metafor/README.ru.md
@@ -28,6 +28,7 @@ bun create metafor auth
 | `-d, --desc <desc>` | Описание Мета | `"MetaFor {name}"` |
 | `--dir <dir>` | Директория для создания | `.` |
 | `-l, --lang <lang>` | Язык вывода (ru\|en) | автодетект |
+| `--self-update` | Принудительное самообновление + очистка кеша npx | - |
 
 ## Примеры
 
@@ -43,6 +44,17 @@ bun create metafor git-commit -d "Коммит"
 
 # Принудительно английский язык
 bun create metafor auth -l en
+```
+
+
+## Обновление
+
+```bash
+# Рекомендуемый запуск без застревания на кеше npx
+npx --yes create-metafor@latest my-meta
+
+# Явно обновить установленную версию
+create-metafor --self-update
 ```
 
 ## Структура

--- a/create-metafor/src/cli.ts
+++ b/create-metafor/src/cli.ts
@@ -21,10 +21,25 @@ import {
   gitAddAll,
   gitCommit,
 } from "./git.ts"
+import { runSelfUpdate } from "./update.ts"
 
 async function main() {
   // Парсинг аргументов
   const args = process.argv.slice(2)
+
+  if (args.includes("--self-update") || args.includes("--update")) {
+    console.log("\n🔄 Обновляю create-metafor до последней версии...\n")
+    const result = await runSelfUpdate()
+
+    if (result.ok) {
+      console.log("\n✅ create-metafor обновлен. Кеш npx очищен.\n")
+      process.exit(0)
+    }
+
+    console.error(`\n❌ Не удалось обновить: ${result.error}\n`)
+    console.error(`Попробуйте вручную: ${result.command.label}\n`)
+    process.exit(1)
+  }
 
   // Если нет аргументов и есть интерактивный терминал — запускаем TUI
   if (args.length === 0 && process.stdin.isTTY) {
@@ -43,7 +58,13 @@ async function main() {
       ? `${__dirname}/tui/tui.tsx` 
       : `${__dirname}/tui.js`
     
-    const child = spawn(runtime, [tuiPath], { stdio: "inherit" })
+    const child = spawn(runtime, [tuiPath], {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        CREATE_METAFOR_PARENT_ARGV: JSON.stringify(process.argv),
+      },
+    })
     child.on("exit", (code) => process.exit(code || 0))
     child.on("error", () => {
       // Если TUI не запустился — показываем help
@@ -78,6 +99,7 @@ ${t.helpOptions}
   -d, --desc <desc>    ${t.optionDesc}
   --dir <dir>          ${t.optionDir} (${t.defaultDesc}: .)
   -l, --lang <lang>    ${t.optionLang}
+  --self-update        self update create-metafor
 
 ${t.helpExamples}
   ${runner} create metafor my-feature
@@ -107,6 +129,7 @@ ${t.helpOptions}
   -d, --desc <desc>    ${t.optionDesc}
   --dir <dir>          ${t.optionDir} (${t.defaultDesc}: .)
   -l, --lang <lang>    ${t.optionLang}
+  --self-update        self update create-metafor
 
 ${t.helpExamples}
   ${runner} create metafor my-feature

--- a/create-metafor/src/tui/components/Form.tsx
+++ b/create-metafor/src/tui/components/Form.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { Box, Text, useInput, useApp } from "ink"
 import { spawn } from "child_process"
-import os from "os"
 import {
   Header,
   InputField,
@@ -14,6 +13,7 @@ import {
 import { useCursor, useScreenSize, useCleanup, useVersionCheck } from "../hooks"
 import type { Field, View, MenuItem } from "../types"
 import packageJson from "../../../package.json"
+import { runSelfUpdate } from "../../update"
 
 interface Props {
   onSubmit: (name: string, description: string, dir: string) => void
@@ -21,9 +21,35 @@ interface Props {
 
 type UpdateButton = "update" | "later"
 
+function relaunchFromParentArgs() {
+  const raw = process.env.CREATE_METAFOR_PARENT_ARGV
+  if (!raw) return false
+
+  try {
+    const argv = JSON.parse(raw) as string[]
+    if (!Array.isArray(argv) || argv.length < 2) return false
+
+    const child = spawn(argv[0], argv.slice(1), {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        CREATE_METAFOR_JUST_UPDATED: "true",
+      },
+    })
+
+    child.on("error", () => {
+      process.exit(0)
+    })
+
+    return true
+  } catch {
+    return false
+  }
+}
+
 export default function Form({ onSubmit }: Props) {
   const { exit: exitApp } = useApp()
-  const { leftWidth, height, width } = useScreenSize()
+  const { leftWidth, height } = useScreenSize()
   useCleanup()
 
   const [field, setField] = useState<Field>("name")
@@ -35,22 +61,19 @@ export default function Form({ onSubmit }: Props) {
   const [selectedItem, setSelectedItem] = useState(0)
   const cursorVisible = useCursor(view)
 
-  // Обновление
   const justUpdated = process.env.CREATE_METAFOR_JUST_UPDATED === "true"
-  const { latestVersion, isLoading, hasUpdate } = useVersionCheck(packageJson.version, justUpdated)
+  const { latestVersion, hasUpdate } = useVersionCheck(packageJson.version, justUpdated)
   const [showUpdateModal, setShowUpdateModal] = useState(false)
   const [selectedButton, setSelectedButton] = useState<UpdateButton>("update")
   const [isUpdating, setIsUpdating] = useState(false)
   const [updateError, setUpdateError] = useState<string | null>(null)
 
-  // Показываем модальное окно если есть обновление (но не сразу после обновления)
   useEffect(() => {
     if (hasUpdate && !showUpdateModal && !isUpdating && !justUpdated) {
       setShowUpdateModal(true)
     }
-  }, [hasUpdate])
+  }, [hasUpdate, showUpdateModal, isUpdating, justUpdated])
 
-  // Скрываем ошибку через 5 секунд
   useEffect(() => {
     if (updateError) {
       const timer = setTimeout(() => setUpdateError(null), 5000)
@@ -68,62 +91,45 @@ export default function Form({ onSubmit }: Props) {
   ]
 
   const getMenuItems = (): MenuItem[] => [
-    { key: "1", label: "Мета для...", action: () => { if (field !== "name") { setField("name"); setInput(name); } } },
-    { key: "2", label: "Мета описание", action: () => { if (field !== "desc") { setField("desc"); setInput(desc); } } },
-    { key: "3", label: "Мета директория", action: () => { if (field !== "dir") { setField("dir"); setInput(dir); } } },
+    { key: "1", label: "Мета для...", action: () => { if (field !== "name") { setField("name"); setInput(name) } } },
+    { key: "2", label: "Мета описание", action: () => { if (field !== "desc") { setField("desc"); setInput(desc) } } },
+    { key: "3", label: "Мета директория", action: () => { if (field !== "dir") { setField("dir"); setInput(dir) } } },
     { key: "q", label: "выход", action: () => exitApp() },
   ]
 
   useInput((inputChar, key) => {
-    // Если есть ошибка — любая клавиша закрывает сообщение
     if (updateError) {
       setUpdateError(null)
       return
     }
 
-    // Обработка модального окна обновления
     if (showUpdateModal) {
-      // Навигация между кнопками
       if (key.leftArrow || key.rightArrow || inputChar === "h" || inputChar === "л" || inputChar === "j" || inputChar === "о") {
         setSelectedButton((prev) => prev === "update" ? "later" : "update")
         return
       }
 
-      // Tab для переключения
       if (key.tab) {
         setSelectedButton((prev) => prev === "update" ? "later" : "update")
         return
       }
 
-      // Enter для выбора
       if (key.return) {
         if (selectedButton === "update") {
           setIsUpdating(true)
           setShowUpdateModal(false)
-          // Запускаем обновление
-          setIsUpdating(true)
-          setShowUpdateModal(false)
 
-          const child = spawn("npm", ["install", "-g", "create-metafor@latest"], {
-            stdio: "pipe",
-          })
-
-          child.on("error", (err: any) => {
+          runSelfUpdate().then((result) => {
             setIsUpdating(false)
-            setUpdateError(`Не удалось запустить npm: ${err.message}. Установите npm или обновите вручную: npm install -g create-metafor@latest`)
-            setShowUpdateModal(true)
-          })
-
-          child.on("close", (code: number) => {
-            setIsUpdating(false)
-            if (code === 0) {
-              // Успешно обновлено
-              setUpdateError(null) // очистим, если было
-              // Выводим сообщение и выходим
-              console.log("\n✅ Обновление выполнено! Пожалуйста, запустите команду снова.\n")
+            if (result.ok) {
+              setUpdateError(null)
+              const relaunched = relaunchFromParentArgs()
+              if (!relaunched) {
+                console.log("\n✅ Обновление выполнено. Перезапустите команду.\n")
+              }
               process.exit(0)
             } else {
-              setUpdateError(`Не удалось обновить (код ${code}). Попробуйте вручную: npm install -g create-metafor@latest`)
+              setUpdateError(`Не удалось обновить (${result.error}). Попробуйте вручную: ${result.command.label}`)
               setShowUpdateModal(true)
             }
           })
@@ -133,16 +139,12 @@ export default function Form({ onSubmit }: Props) {
         return
       }
 
-      // Esc — позже
       if (key.escape) {
         setShowUpdateModal(false)
-        return
       }
-
       return
     }
 
-    // Основной режим
     if (key.escape) {
       exitApp()
       return
@@ -158,11 +160,9 @@ export default function Form({ onSubmit }: Props) {
       return
     }
 
-    // Навигация в меню/помощи (vim-like + стрелки)
     if (view !== "input") {
       const items = view === "help" ? getHelpItems() : getMenuItems()
 
-      // vim-like навигация (j/k и русские о/л)
       if (key.upArrow || inputChar === "k" || inputChar === "л") {
         setSelectedItem((prev) => (prev > 0 ? prev - 1 : items.length - 1))
         return
@@ -173,7 +173,6 @@ export default function Form({ onSubmit }: Props) {
         return
       }
 
-      // Enter — выбор пункта меню
       if (key.return && view === "menu") {
         const item = items[selectedItem]
         if (item?.action) {
@@ -183,7 +182,6 @@ export default function Form({ onSubmit }: Props) {
         return
       }
 
-      // Выбор пункта меню по клавише
       if (view === "menu" && inputChar) {
         const item = items.find((m) => m.key === inputChar)
         if (item?.action) {
@@ -191,27 +189,10 @@ export default function Form({ onSubmit }: Props) {
           setView("input")
         }
       }
-
       return
     }
 
-    // Ввод в режиме input
-    if (key.return) {
-      if (field === "name") {
-        setName(input.trim())
-        setField("desc")
-        setInput("")
-      } else if (field === "desc") {
-        setDesc(input.trim() || `MetaFor ${name}`)
-        setField("dir")
-        setInput("")
-      } else if (field === "dir") {
-        onSubmit(name, desc, input.trim() || ".")
-      }
-      return
-    }
-
-    if (key.tab) {
+    if (key.return || key.tab) {
       if (field === "name") {
         setName(input.trim())
         setField("desc")
@@ -243,10 +224,7 @@ export default function Form({ onSubmit }: Props) {
     return cursorVisible ? "▓" : " "
   }
 
-  const isInteractive = view !== "input"
-  const borderColor = isInteractive ? "white" : "gray"
-
-  // Если показано модальное окно — скрываем основной контент
+  const borderColor = view !== "input" ? "white" : "gray"
   const showOverlay = showUpdateModal || updateError
 
   return (
@@ -255,21 +233,9 @@ export default function Form({ onSubmit }: Props) {
 
       {!showOverlay ? (
         <Box flexGrow={1}>
-          <InputField
-            input={input}
-            cursor={renderCursor()}
-            isActive={view === "input"}
-            width={leftWidth}
-          />
+          <InputField input={input} cursor={renderCursor()} isActive={view === "input"} width={leftWidth} />
 
-          <Box
-            flexGrow={1}
-            flexDirection="column"
-            borderStyle="single"
-            borderColor={borderColor}
-            marginLeft={1}
-            paddingLeft={1}
-          >
+          <Box flexGrow={1} flexDirection="column" borderStyle="single" borderColor={borderColor} marginLeft={1} paddingLeft={1}>
             {view === "input" ? (
               <Preview name={name} desc={desc} dir={dir} />
             ) : view === "help" ? (
@@ -288,13 +254,7 @@ export default function Form({ onSubmit }: Props) {
               selectedButton={selectedButton}
             />
           ) : (
-            <Box
-              flexDirection="column"
-              borderStyle="round"
-              borderColor="red"
-              padding={1}
-              width={52}
-            >
+            <Box flexDirection="column" borderStyle="round" borderColor="red" padding={1} width={52}>
               <Box justifyContent="center" marginBottom={1}>
                 <Text bold color="red">Ошибка обновления</Text>
               </Box>

--- a/create-metafor/src/tui/hooks/useVersionCheck.ts
+++ b/create-metafor/src/tui/hooks/useVersionCheck.ts
@@ -1,10 +1,44 @@
 import { useState, useEffect } from "react"
 import { Worker } from "worker_threads"
+import { existsSync } from "fs"
 import { fileURLToPath } from "url"
-import { dirname, join } from "path"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+function toParts(version: string) {
+  return version.replace(/^v/, "").split(".").map((part) => Number(part) || 0)
+}
+
+function isNewerVersion(latest: string, current: string) {
+  const a = toParts(latest)
+  const b = toParts(current)
+  const length = Math.max(a.length, b.length)
+
+  for (let i = 0; i < length; i++) {
+    const left = a[i] || 0
+    const right = b[i] || 0
+    if (left > right) return true
+    if (left < right) return false
+  }
+
+  return false
+}
+
+function resolveWorkerPath() {
+  const candidates = [
+    new URL("../workers/version-checker.js", import.meta.url),
+    new URL("./workers/version-checker.js", import.meta.url),
+    new URL("../workers/version-checker.ts", import.meta.url),
+    new URL("./workers/version-checker.ts", import.meta.url),
+  ]
+
+  for (const candidate of candidates) {
+    const path = fileURLToPath(candidate)
+    if (existsSync(path)) {
+      return path
+    }
+  }
+
+  return fileURLToPath(new URL("../workers/version-checker.js", import.meta.url))
+}
 
 export function useVersionCheck(currentVersion: string, skipCheck = false) {
   const [latestVersion, setLatestVersion] = useState<string | null>(null)
@@ -17,19 +51,20 @@ export function useVersionCheck(currentVersion: string, skipCheck = false) {
       return
     }
 
-    const workerPath = join(__dirname, "workers", "version-checker.js")
-    const worker = new Worker(workerPath)
+    const worker = new Worker(resolveWorkerPath())
 
     worker.on("message", (msg: any) => {
       if (msg.type === "latest") {
         setLatestVersion(msg.version)
         setIsLoading(false)
-        if (msg.version !== currentVersion) {
-          setHasUpdate(true)
-        }
+        setHasUpdate(isNewerVersion(msg.version, currentVersion))
       } else if (msg.type === "error") {
         setIsLoading(false)
       }
+    })
+
+    worker.on("error", () => {
+      setIsLoading(false)
     })
 
     return () => {

--- a/create-metafor/src/tui/workers/version-checker.ts
+++ b/create-metafor/src/tui/workers/version-checker.ts
@@ -1,12 +1,27 @@
 import { parentPort } from "worker_threads"
 
 async function checkLatestVersion() {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 4000)
+
   try {
-    const response = await fetch("https://registry.npmjs.org/create-metafor/latest")
+    const response = await fetch("https://registry.npmjs.org/create-metafor/latest", {
+      headers: {
+        "cache-control": "no-cache",
+      },
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`npm registry responded with ${response.status}`)
+    }
+
     const data: any = await response.json()
     parentPort?.postMessage({ type: "latest", version: data.version })
   } catch (error: any) {
     parentPort?.postMessage({ type: "error", error: error.message })
+  } finally {
+    clearTimeout(timeout)
   }
 }
 

--- a/create-metafor/src/update.ts
+++ b/create-metafor/src/update.ts
@@ -1,0 +1,84 @@
+import { spawn } from "child_process"
+import { existsSync, rmSync } from "fs"
+import os from "os"
+import { join } from "path"
+
+const PACKAGE_NAME = "create-metafor"
+
+export interface UpdateCommand {
+  command: string
+  args: string[]
+  label: string
+}
+
+export function getSelfUpdateCommand(userAgent = process.env.npm_config_user_agent || ""): UpdateCommand {
+  const ua = userAgent.toLowerCase()
+
+  if (ua.includes("bun/")) {
+    return {
+      command: "bun",
+      args: ["add", "-g", `${PACKAGE_NAME}@latest`],
+      label: "bun add -g create-metafor@latest",
+    }
+  }
+
+  if (ua.includes("pnpm/")) {
+    return {
+      command: "pnpm",
+      args: ["add", "-g", `${PACKAGE_NAME}@latest`],
+      label: "pnpm add -g create-metafor@latest",
+    }
+  }
+
+  return {
+    command: "npm",
+    args: ["install", "-g", `${PACKAGE_NAME}@latest`, "--force"],
+    label: "npm install -g create-metafor@latest --force",
+  }
+}
+
+function cleanupNpxCache() {
+  const home = os.homedir()
+  const candidates = [
+    join(home, ".npm", "_npx"),
+    join(home, ".cache", "npm", "_npx"),
+  ]
+
+  for (const path of candidates) {
+    if (existsSync(path)) {
+      rmSync(path, { recursive: true, force: true })
+    }
+  }
+}
+
+export async function runSelfUpdate(): Promise<{ ok: boolean, error?: string, command: UpdateCommand }> {
+  const updateCommand = getSelfUpdateCommand()
+
+  return new Promise((resolve) => {
+    const child = spawn(updateCommand.command, updateCommand.args, {
+      stdio: "inherit",
+    })
+
+    child.on("error", (error: Error) => {
+      resolve({
+        ok: false,
+        error: error.message,
+        command: updateCommand,
+      })
+    })
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        cleanupNpxCache()
+        resolve({ ok: true, command: updateCommand })
+        return
+      }
+
+      resolve({
+        ok: false,
+        error: `exit code ${code}`,
+        command: updateCommand,
+      })
+    })
+  })
+}

--- a/create-metafor/tests/update.test.ts
+++ b/create-metafor/tests/update.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { getSelfUpdateCommand } from "../src/update"
+
+describe("getSelfUpdateCommand", () => {
+  test("uses bun for bun user agent", () => {
+    const result = getSelfUpdateCommand("bun/1.2.0")
+    expect(result.command).toBe("bun")
+    expect(result.args.join(" ")).toContain("add -g create-metafor@latest")
+  })
+
+  test("uses pnpm for pnpm user agent", () => {
+    const result = getSelfUpdateCommand("pnpm/9.0.0 npm/? node/v20")
+    expect(result.command).toBe("pnpm")
+  })
+
+  test("falls back to npm and force update", () => {
+    const result = getSelfUpdateCommand("npm/10.0.0")
+    expect(result.command).toBe("npm")
+    expect(result.args).toContain("--force")
+  })
+})


### PR DESCRIPTION
### Motivation
- Restore reliable remote version detection so the TUI shows the update modal again instead of silently failing.
- Provide an in-TUI update flow that actually performs the self-update and restarts the tool so users don't have to copy/paste commands.
- Make self-update robust across runtimes (`bun`/`pnpm`/`npm`) and avoid stale `npx` cache problems after upgrade.

### Description
- Add `create-metafor/src/update.ts` with `getSelfUpdateCommand` and `runSelfUpdate` to pick correct package-manager (`bun`/`pnpm`/`npm`), run the update, and clean common `npx` cache folders.
- Wire CLI handling for `--self-update`/`--update` in `create-metafor/src/cli.ts` to call `runSelfUpdate` and exit with clear messages, and pass parent argv to the TUI via `CREATE_METAFOR_PARENT_ARGV` for relaunch continuity.
- Update TUI`create-metafor/src/tui/components/Form.tsx` to show the update modal reliably, call `runSelfUpdate` when accepted, and attempt an automatic relaunch using the saved parent argv (`relaunchFromParentArgs`) instead of just exiting.
- Fix `create-metafor/src/tui/hooks/useVersionCheck.ts` to resolve the worker path in both source and bundled layouts and use a numeric semver-like comparison to determine `hasUpdate`.
- Improve the worker `create-metafor/src/tui/workers/version-checker.ts` to use a fetch timeout and `cache-control: no-cache`, and report errors back to the TUI worker.
- Add `create-metafor/tests/update.test.ts` to validate package-manager command selection, and document update usage in `README.md` / `README.ru.md` (including `npx --yes create-metafor@latest` and `create-metafor --self-update`).

### Testing
- Ran `bun test` in `create-metafor`; all tests passed (24 tests, new updater tests included). ✅
- Attempted `bun run build` in this environment but it failed due to unresolved local workspace dependencies (`ink` / runtime linking), which is an environment/setup limitation and not caused by these changes. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989c98db0c83308770525573e6302c)