### PR TITLE
fix(create-metafor): restart TUI flow after successful self-update

### DIFF
--- a/create-metafor/src/tui/components/Form.tsx
+++ b/create-metafor/src/tui/components/Form.tsx
@@ -12,7 +12,7 @@ import {
 import { useCursor, useScreenSize, useCleanup, useVersionCheck } from "../hooks"
 import type { Field, View, MenuItem } from "../types"
 import packageJson from "../../../package.json"
-import { runSelfUpdate } from "../../update"
+import { runSelfUpdate, restartCurrentProcess } from "../../update"
 
 interface Props {
   onSubmit: (name: string, description: string, dir: string) => void
@@ -104,7 +104,10 @@ export default function Form({ onSubmit }: Props) {
             setIsUpdating(false)
             if (result.ok) {
               setUpdateError(null)
-              console.log("\n✅ Обновление выполнено. Кеш npx очищен, перезапустите команду.\n")
+              const restarted = restartCurrentProcess()
+              if (!restarted) {
+                console.log("\n✅ Обновление выполнено. Кеш npx очищен, перезапустите команду вручную.\n")
+              }
               process.exit(0)
             } else {
               setUpdateError(`Не удалось обновить (${result.error}). Попробуйте вручную: ${result.command.label}`)

--- a/create-metafor/src/update.ts
+++ b/create-metafor/src/update.ts
@@ -11,6 +11,11 @@ export interface UpdateCommand {
   label: string
 }
 
+export interface RestartCommand {
+  command: string
+  args: string[]
+}
+
 export function getSelfUpdateCommand(userAgent = process.env.npm_config_user_agent || ""): UpdateCommand {
   const ua = userAgent.toLowerCase()
 
@@ -81,4 +86,38 @@ export async function runSelfUpdate(): Promise<{ ok: boolean, error?: string, co
       })
     })
   })
+}
+
+export function getRestartCommand(argv = process.argv): RestartCommand {
+  if (argv.length <= 1) {
+    return {
+      command: process.execPath,
+      args: [],
+    }
+  }
+
+  return {
+    command: process.execPath,
+    args: argv.slice(1),
+  }
+}
+
+export function restartCurrentProcess(argv = process.argv): boolean {
+  const restartCommand = getRestartCommand(argv)
+
+  try {
+    const child = spawn(restartCommand.command, restartCommand.args, {
+      stdio: "inherit",
+      detached: true,
+      env: {
+        ...process.env,
+        CREATE_METAFOR_JUST_UPDATED: "true",
+      },
+    })
+
+    child.unref()
+    return true
+  } catch {
+    return false
+  }
 }

--- a/create-metafor/tests/update.test.ts
+++ b/create-metafor/tests/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { getSelfUpdateCommand } from "../src/update"
+import { getRestartCommand, getSelfUpdateCommand } from "../src/update"
 
 describe("getSelfUpdateCommand", () => {
   test("uses bun for bun user agent", () => {
@@ -17,5 +17,19 @@ describe("getSelfUpdateCommand", () => {
     const result = getSelfUpdateCommand("npm/10.0.0")
     expect(result.command).toBe("npm")
     expect(result.args).toContain("--force")
+  })
+})
+
+describe("getRestartCommand", () => {
+  test("restarts current script with passed args", () => {
+    const result = getRestartCommand(["node", "/tmp/dist/tui.js", "--foo"])
+    expect(result.command).toBe(process.execPath)
+    expect(result.args).toEqual(["/tmp/dist/tui.js", "--foo"])
+  })
+
+  test("returns only executable when argv has no script", () => {
+    const result = getRestartCommand(["node"])
+    expect(result.command).toBe(process.execPath)
+    expect(result.args).toEqual([])
   })
 })


### PR DESCRIPTION
### Motivation
- The TUI showed an update modal and could install a new version but did not attempt to relaunch itself automatically after a successful self-update, leaving the user to restart manually.
- Restart should be performed transparently and the TUI must not re-open the update prompt immediately after relaunch.

### Description
- Added restart helpers in `create-metafor/src/update.ts`: `getRestartCommand()` to build the restart invocation from `process.argv` and `restartCurrentProcess()` to spawn a detached process with `CREATE_METAFOR_JUST_UPDATED=true` set in the environment.
- Updated the TUI confirm flow in `create-metafor/src/tui/components/Form.tsx` to call `restartCurrentProcess()` after `runSelfUpdate()` succeeds and fall back to a manual-restart message only if automatic restart fails.
- Added tests in `create-metafor/tests/update.test.ts` for `getRestartCommand()` to cover both argv-with-script and argv-only cases.

### Testing
- Ran `bun test create-metafor/tests/update.test.ts` and all tests in that file passed (5 pass, 0 fail). 
- Ran `bun test create-metafor/tests` (project test subset) and the suite passed (26 pass, 0 fail across 4 files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a25b00948330bddb6baf74d3f0e3)