### PR TITLE
Добавить минимальный Dark Boundary Matrix Energy universe

### DIFF
--- a/.github/workflows/core-runtime.yml
+++ b/.github/workflows/core-runtime.yml
@@ -14,6 +14,7 @@ on:
       - "matrix/**"
       - "energy/**"
       - "fixture/**"
+      - "github/**"
   push:
     branches: [main]
     paths:
@@ -27,6 +28,7 @@ on:
       - "matrix/**"
       - "energy/**"
       - "fixture/**"
+      - "github/**"
   workflow_dispatch:
 
 permissions:
@@ -72,7 +74,8 @@ jobs:
               boundary/runtime/matrix.spec.ts \
               matrix/matrix.spec.ts \
               matrix/weak/device.spec.ts \
-              matrix/runtime.parity.spec.ts
+              matrix/runtime.parity.spec.ts \
+              fixture/runtime-universe.spec.ts
             do
               echo "::group::$test_file"
               bun test "$test_file"

--- a/boundary/server.ts
+++ b/boundary/server.ts
@@ -55,7 +55,7 @@ force.onImpulse = async (message) => {
 }
 
 const server = Bun.serve({
-  port: 4001,
+  port: Number(Bun.env.PORT ?? 4001),
   routes: {
     "/health": {
       GET() {

--- a/energy/server.ts
+++ b/energy/server.ts
@@ -3,7 +3,7 @@ import {startEnergyProtocol} from "./energy.ts"
 startEnergyProtocol()
 
 const server = Bun.serve({
-  port: 4005,
+  port: Number(Bun.env.PORT ?? 4005),
   routes: {
     "/health": {
       GET() {

--- a/fixture/runtime-universe.spec.ts
+++ b/fixture/runtime-universe.spec.ts
@@ -1,0 +1,317 @@
+import {describe, expect, test} from "bun:test"
+import {mkdtempSync, rmSync} from "node:fs"
+import {tmpdir} from "node:os"
+import {join, resolve} from "node:path"
+import type {ForceMessage} from "@metafor/types/force/message"
+import type {Particle} from "@metafor/types/force/particle"
+import {boundaryEntityId} from "../boundary/incremental.ts"
+
+const ROOT = "test/runtime-universe"
+const repositoryRoot = resolve(import.meta.dir, "..")
+const inheritedEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+)
+
+type ProcessLine = {
+  stream: "stdout" | "stderr"
+  text: string
+}
+
+type ManagedProcess = {
+  name: string
+  process: ReturnType<typeof Bun.spawn>
+  lines: ProcessLine[]
+  waitForLine(predicate: (line: string) => boolean, fromIndex?: number, timeoutMs?: number): Promise<{lineIndex: number; line: string}>
+  stop(): Promise<void>
+}
+
+type ForceEvent = {
+  lineIndex: number
+  source: string
+  direction: "<-" | "->"
+  message: ForceMessage
+  line: string
+}
+
+const consumeLines = async (
+  stream: ReadableStream<Uint8Array>,
+  channel: ProcessLine["stream"],
+  lines: ProcessLine[],
+): Promise<void> => {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let pending = ""
+
+  while (true) {
+    const {done, value} = await reader.read()
+    if (value) pending += decoder.decode(value, {stream: !done})
+    let newline = pending.indexOf("\n")
+    while (newline !== -1) {
+      const text = pending.slice(0, newline).replace(/\r$/, "")
+      pending = pending.slice(newline + 1)
+      if (text.length > 0) lines.push({stream: channel, text})
+      newline = pending.indexOf("\n")
+    }
+    if (done) break
+  }
+
+  pending += decoder.decode()
+  const text = pending.replace(/\r$/, "")
+  if (text.length > 0) lines.push({stream: channel, text})
+}
+
+const spawnManaged = (
+  name: string,
+  entry: string,
+  env: Record<string, string>,
+): ManagedProcess => {
+  const lines: ProcessLine[] = []
+  const subprocess = Bun.spawn({
+    cmd: ["bun", entry],
+    cwd: repositoryRoot,
+    env: {...inheritedEnv, ...env},
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  void consumeLines(subprocess.stdout as ReadableStream<Uint8Array>, "stdout", lines)
+  void consumeLines(subprocess.stderr as ReadableStream<Uint8Array>, "stderr", lines)
+
+  return {
+    name,
+    process: subprocess,
+    lines,
+    async waitForLine(predicate, fromIndex = 0, timeoutMs = 15_000) {
+      const deadline = Date.now() + timeoutMs
+      while (Date.now() < deadline) {
+        for (let lineIndex = fromIndex; lineIndex < lines.length; lineIndex++) {
+          const line = lines[lineIndex]!.text
+          if (predicate(line)) return {lineIndex, line}
+        }
+        if (subprocess.exitCode !== null) {
+          throw new Error(`${name} exited with ${subprocess.exitCode}:\n${lines.slice(-30).map((item) => item.text).join("\n")}`)
+        }
+        await Bun.sleep(20)
+      }
+      throw new Error(`Timed out waiting for ${name} output:\n${lines.slice(-30).map((item) => item.text).join("\n")}`)
+    },
+    async stop() {
+      if (subprocess.exitCode !== null) return
+      subprocess.kill("SIGTERM")
+      await Promise.race([subprocess.exited, Bun.sleep(2_000)])
+      if (subprocess.exitCode === null) subprocess.kill("SIGKILL")
+    },
+  }
+}
+
+const parseForceEvent = (line: string, lineIndex: number): ForceEvent | null => {
+  const match = /^\[[^\]]+\]\s+#\d+\s+(\S+)\s+(<-|->)\s+(\{.*\})$/.exec(line)
+  if (!match) return null
+  try {
+    const message = JSON.parse(match[3]!) as ForceMessage
+    if (!Array.isArray(message.parts) || message.parts.length !== 1) return null
+    return {
+      lineIndex,
+      source: match[1]!,
+      direction: match[2]! as "<-" | "->",
+      message,
+      line,
+    }
+  } catch {
+    return null
+  }
+}
+
+const waitForForceEvent = async (
+  force: ManagedProcess,
+  predicate: (event: ForceEvent) => boolean,
+  fromIndex = 0,
+  timeoutMs = 20_000,
+): Promise<ForceEvent> => {
+  const result = await force.waitForLine((line) => {
+    const lineIndex = force.lines.findIndex((item) => item.text === line)
+    const event = parseForceEvent(line, lineIndex)
+    return event !== null && predicate(event)
+  }, fromIndex, timeoutMs)
+  const event = parseForceEvent(result.line, result.lineIndex)
+  if (!event) throw new Error(`Expected Force event, received: ${result.line}`)
+  return event
+}
+
+const particle = (event: ForceEvent): Particle => event.message.parts[0]!
+
+const postImpulse = async (baseUrl: string, part: Particle): Promise<void> => {
+  const response = await fetch(`${baseUrl}/force`, {
+    method: "POST",
+    headers: {"content-type": "application/json"},
+    body: JSON.stringify({parts: [part]} satisfies ForceMessage),
+  })
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual({ok: true, parts: 1})
+}
+
+const eventLabel = (event: ForceEvent): string => {
+  const part = particle(event)
+  return `${event.source} ${part.part}/${part.op} ${String(part.path)}${part.value === undefined ? "" : ` ${JSON.stringify(part.value)}`}`
+}
+
+describe("minimal MetaFor runtime universe", () => {
+  test("runs Dark → Boundary → Matrix → Energy without Bulk or interpreter", async () => {
+    const temporary = mkdtempSync(join(tmpdir(), "metafor-runtime-universe-"))
+    const database = join(temporary, "boundary.sqlite")
+    const processes: ManagedProcess[] = []
+
+    try {
+      const force = spawnManaged("force", "force/server.ts", {
+        PORT: "0",
+        METAFOR_LOG_IMPULSES: "full",
+      })
+      processes.push(force)
+      const listening = await force.waitForLine((line) => line.includes("[force] listening on "))
+      const port = /:(\d+)\/?$/.exec(listening.line)?.[1]
+      if (!port) throw new Error(`Cannot parse Force port from: ${listening.line}`)
+      const forceAddress = `ws://127.0.0.1:${port}/ws`
+      const forceHttp = `http://127.0.0.1:${port}`
+      const domainEnv = {
+        FORCE_ADDRESS: forceAddress,
+        FORCE_RECONNECT: "0",
+        METAFOR_LOG_IMPULSES: "off",
+        PORT: "0",
+      }
+
+      const boundary = spawnManaged("boundary", "boundary/server.ts", {
+        ...domainEnv,
+        BOUNDARY_PATH: database,
+      })
+      processes.push(boundary)
+      await force.waitForLine((line) => line.includes("[force] connected: boundary boundary-local"))
+
+      const matrix = spawnManaged("matrix", "matrix/server.ts", {
+        ...domainEnv,
+        METAFOR_WEAK_BACKEND: "cpu",
+      })
+      processes.push(matrix)
+      await force.waitForLine((line) => line.includes("[force] connected: matrix matrix-local"))
+
+      const energy = spawnManaged("energy", "energy/server.ts", {
+        ...domainEnv,
+        ENERGY_ID: "energy-universe",
+        ENERGY_RUNTIME_KIND: "server",
+      })
+      processes.push(energy)
+      await force.waitForLine((line) => line.includes("[force] connected: energy energy-local"))
+
+      const dark = spawnManaged("dark", "dark/server.ts", domainEnv)
+      processes.push(dark)
+      await force.waitForLine((line) => line.includes("[force] connected: dark dark-local"))
+
+      const activationStart = force.lines.length
+      await postImpulse(forceHttp, {part: "inflaton", op: "test", path: ROOT})
+
+      const darkMeta = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:dark" && particle(event).part === "inflaton" &&
+          particle(event).op === "add" && particle(event).path === `${ROOT}/meta`,
+        activationStart,
+      )
+      const boundaryProcess = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:boundary" && particle(event).part === "graviton" &&
+          particle(event).path === `declaration/${ROOT}/processes/1`,
+        darkMeta.lineIndex + 1,
+      )
+      const boundaryActor = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:boundary" && particle(event).part === "graviton" &&
+          particle(event).op === "add" && typeof particle(event).path === "string" &&
+          String(particle(event).path).startsWith("actor/"),
+        darkMeta.lineIndex + 1,
+      )
+      const bootstrap = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:boundary" && particle(event).part === "graviton" &&
+          particle(event).op === "replace" && particle(event).path === "runtime/matrix",
+        Math.max(boundaryProcess.lineIndex, boundaryActor.lineIndex) + 1,
+      )
+      const idle = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:matrix" && particle(event).part === "photon" &&
+          particle(event).op === "replace" && particle(event).value === "idle",
+        bootstrap.lineIndex + 1,
+      )
+
+      const actorId = Number(particle(idle).path)
+      expect(Number.isSafeInteger(actorId) && actorId > 0).toBe(true)
+      expect(particle(boundaryActor).path).toBe(`actor/${actorId}`)
+
+      const inputFieldId = boundaryEntityId(`${ROOT}/fields/1`)
+      const outputFieldId = boundaryEntityId(`${ROOT}/fields/2`)
+      const inputStart = force.lines.length
+      await postImpulse(forceHttp, {
+        part: "gluon",
+        op: "replace",
+        path: actorId,
+        value: {fields: {[String(inputFieldId)]: 1}},
+      })
+
+      const input = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:http" && particle(event).part === "gluon" &&
+          particle(event).path === actorId,
+        inputStart,
+      )
+      const ready = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:matrix" && particle(event).part === "photon" &&
+          particle(event).op === "test" && particle(event).path === actorId && particle(event).value === "ready",
+        input.lineIndex + 1,
+      )
+      const claim = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:energy" && particle(event).part === "z" &&
+          particle(event).op === "test" && particle(event).path === actorId,
+        ready.lineIndex + 1,
+      )
+      const copy = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:matrix" && particle(event).part === "z" &&
+          particle(event).op === "copy" && particle(event).path === actorId,
+        claim.lineIndex + 1,
+      )
+      const result = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:energy" && particle(event).part === "w+" &&
+          particle(event).op === "replace" && particle(event).path === actorId,
+        copy.lineIndex + 1,
+      )
+      const complete = await waitForForceEvent(
+        force,
+        (event) => event.source === "force:matrix" && particle(event).part === "photon" &&
+          particle(event).op === "replace" && particle(event).path === actorId && particle(event).value === "complete",
+        result.lineIndex + 1,
+      )
+
+      expect((particle(claim).value as {energy?: unknown}).energy).toBe("energy-universe")
+      expect(particle(copy).from).toBe("energy-universe")
+      expect((particle(copy).value as {fields?: unknown}).fields).toEqual({
+        [String(inputFieldId)]: 1,
+        [String(outputFieldId)]: 0,
+      })
+      expect((particle(result).value as {fields?: unknown}).fields).toEqual({
+        [String(outputFieldId)]: 2,
+      })
+      expect(force.lines.some((item) => item.text.includes("[force] connected: bulk "))).toBe(false)
+      expect(force.lines.some((item) => item.text.includes("[force] connected: interpreter "))).toBe(false)
+
+      const trace = [darkMeta, boundaryProcess, boundaryActor, bootstrap, idle, input, ready, claim, copy, result, complete]
+      for (let index = 1; index < trace.length; index++) {
+        expect(trace[index]!.lineIndex).toBeGreaterThan(trace[index - 1]!.lineIndex)
+      }
+      console.log(`[runtime-universe]\n${trace.map(eventLabel).join("\n")}`)
+    } finally {
+      for (const managed of processes.toReversed()) await managed.stop()
+      rmSync(temporary, {recursive: true, force: true})
+    }
+  }, 60_000)
+})

--- a/fixture/runtime-universe.spec.ts
+++ b/fixture/runtime-universe.spec.ts
@@ -304,10 +304,14 @@ describe("minimal MetaFor runtime universe", () => {
       expect(force.lines.some((item) => item.text.includes("[force] connected: bulk "))).toBe(false)
       expect(force.lines.some((item) => item.text.includes("[force] connected: interpreter "))).toBe(false)
 
-      const trace = [darkMeta, boundaryProcess, boundaryActor, bootstrap, idle, input, ready, claim, copy, result, complete]
-      for (let index = 1; index < trace.length; index++) {
-        expect(trace[index]!.lineIndex).toBeGreaterThan(trace[index - 1]!.lineIndex)
+      expect(boundaryActor.lineIndex).toBeGreaterThan(darkMeta.lineIndex)
+      expect(boundaryProcess.lineIndex).toBeGreaterThan(darkMeta.lineIndex)
+      expect(bootstrap.lineIndex).toBeGreaterThan(Math.max(boundaryActor.lineIndex, boundaryProcess.lineIndex))
+      const runtimeTrace = [bootstrap, idle, input, ready, claim, copy, result, complete]
+      for (let index = 1; index < runtimeTrace.length; index++) {
+        expect(runtimeTrace[index]!.lineIndex).toBeGreaterThan(runtimeTrace[index - 1]!.lineIndex)
       }
+      const trace = [darkMeta, boundaryActor, boundaryProcess, ...runtimeTrace].sort((left, right) => left.lineIndex - right.lineIndex)
       console.log(`[runtime-universe]\n${trace.map(eventLabel).join("\n")}`)
     } finally {
       for (const managed of processes.toReversed()) await managed.stop()

--- a/github/test/runtime-universe/meta.ts
+++ b/github/test/runtime-universe/meta.ts
@@ -1,0 +1,37 @@
+import type {MetaDSL} from "@metafor/types/metafor/schema"
+
+/**
+ * Neutral integration universe for the first observable core lifecycle.
+ * It intentionally has no Matter children, Bulk, browser or provider binding.
+ */
+const meta = {
+  name: "Runtime Universe",
+  desc: "input=0 → input=1 → Energy process → output=2 → complete",
+  fields: [
+    {key: "input", type: "number", required: true, default: 0},
+    {key: "output", type: "number", required: true, default: 0},
+  ],
+  superposition: [
+    {name: "idle", transitions: {ready: {input: {eq: 1}}}},
+    {name: "ready", transitions: {complete: {output: {eq: 2}}}},
+    {name: "complete"},
+  ],
+  processes: [{
+    key: "ready",
+    declaration: {
+      type: "action",
+      env: ["server"],
+      action: {
+        src: "./unused.ts",
+        wrapperSrc: "({value}) => ({output: Number(value.input) + 1})",
+        read: ["input"],
+      },
+      success: {
+        src: "({update, data}) => update({output: data.output})",
+        write: ["output"],
+      },
+    },
+  }],
+} satisfies MetaDSL
+
+export default meta

--- a/matrix/server.ts
+++ b/matrix/server.ts
@@ -1,7 +1,7 @@
 import "./matrix.ts"
 
 const server = Bun.serve({
-  port: 4003,
+  port: Number(Bun.env.PORT ?? 4003),
   routes: {
     "/health": {
       GET() {
@@ -12,4 +12,3 @@ const server = Bun.serve({
 })
 
 console.log(`[matrix] listening on ${server.url}`)
-

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "upd": "bun update --latest && bun i",
     "clear": "rm -rf node_modules && bun run --parallel --filter '*' clear",
     "test:dark-server": "bun test dark/server.spec.ts",
+    "test:runtime-universe": "bun test fixture/runtime-universe.spec.ts",
     "test:all": "bun test",
     "build": "bun run build:prod && bun run build:dev",
     "build:watch": "bun run build:dev --watch",


### PR DESCRIPTION
## Цель

Закрыть первый настоящий сквозной core lifecycle без Bulk, interpreter, browser shell и product adapters.

## Neutral Meta

Добавлена `github/test/runtime-universe/meta.ts`:

```text
input = 0
→ idle
→ external Gluon input = 1
→ ready
→ Energy Process
→ declared output = 2
→ complete
```

Process использует serializable `wrapperSrc`, читает только `input`, а success handler записывает только declared `output`.

## Отдельные production processes

`fixture/runtime-universe.spec.ts` запускает:

```text
Force
Boundary + fresh SQLite
Matrix CPU packed runtime
Energy server
Dark server
```

Activation приходит обычным HTTP Force Impulse:

```text
inflaton/test test/runtime-universe
```

Домены общаются только через реальный WebSocket relay. Matrix и Energy не импортируют и не читают Boundary.

## Фактически полученный trace

GitHub Actions зафиксировал:

```text
force:dark     inflaton/add meta
force:boundary graviton/add actor/1
force:boundary graviton/add process/ready
force:boundary graviton/replace runtime/matrix
force:matrix   photon/replace idle
force:http     gluon/replace input=1
force:matrix   photon/test ready
force:energy   z/test energy-universe
force:matrix   z/copy frozen input=1 output=0
force:energy   w+/replace output=2
force:matrix   photon/replace complete
```

Проверены:

- actor identity между Boundary и Matrix;
- реальные 52-bit field IDs;
- process catalog до Photon/ready;
- frozen read set `{input: 1, output: 0}`;
- W+ содержит только declared output write set;
- строгий causal order после Matrix bootstrap;
- отсутствие Bulk и interpreter connections.

## Test result

На commit `2e6a49898a29f8fbcd7d382270feb76fc645e213` зелёные:

```text
CPU reference and typecheck — success
WebGPU parity on Vulkan software adapter — success
```

`fixture/runtime-universe.spec.ts` прошёл за ~0.35 s, 22 assertions.

## Supporting changes

- Boundary, Matrix и Energy health servers принимают `PORT`, сохраняя прежние defaults;
- `bun run test:runtime-universe` запускает сценарий локально;
- test включён в read-only `Core Runtime Verification` и trace сохраняется в artifacts.

## Незакрытая граница

External Gluon и W+ пока меняют runtime Matrix, а не canonical Boundary. Это не скрывается тестом и становится следующим отдельным этапом:

```text
W result
→ validate declared writes
→ Boundary atomic commit
→ derived consequences
→ Matrix unlock/re-evaluate
→ Reaction
```
