### PR TITLE
Завершить canonical Reaction path

### DIFF
--- a/.github/workflows/core-runtime.yml
+++ b/.github/workflows/core-runtime.yml
@@ -72,11 +72,14 @@ jobs:
               force/core/log.test.ts \
               force/server.test.ts \
               boundary/runtime/matrix.spec.ts \
+              boundary/state.spec.ts \
               boundary/execution.spec.ts \
+              boundary/reaction.spec.ts \
               matrix/matrix.spec.ts \
               matrix/weak/device.spec.ts \
               matrix/runtime.parity.spec.ts \
               energy/energy.spec.ts \
+              energy/reaction.spec.ts \
               fixture/runtime-universe.spec.ts
             do
               echo "::group::$test_file"

--- a/boundary/execution.ts
+++ b/boundary/execution.ts
@@ -1,15 +1,14 @@
 import type {ReservedSQL, SQL} from "bun"
 import type {
-  ProcessExecutionClaim,
   ProcessExecutionGrant,
   ProcessResultCommit,
   ProcessResultProposal,
 } from "@metafor/types/force/execution"
 import {isProcessExecutionId} from "@metafor/types/force/execution"
-import {resolveForceFieldId} from "@metafor/types/force/fields"
 import type {ForceMessage} from "@metafor/types/force/message"
 import type {Particle} from "@metafor/types/force/particle"
 import type {BoundaryIncrementalCommit} from "./incremental.ts"
+import {commitBoundaryActorFields} from "./world.ts"
 
 type Database = SQL | ReservedSQL
 type JsonRecord = Record<string, unknown>
@@ -40,11 +39,6 @@ type CanonicalProcess = {
   wimp: string
   state: string
   descriptor: JsonRecord
-}
-
-type FieldRow = {
-  id: number
-  type: string
 }
 
 const isRecord = (value: unknown): value is JsonRecord =>
@@ -81,7 +75,6 @@ const proposalValue = (value: unknown): ProcessResultProposal | null => {
 
 /**
  * Boundary-owned State and Process execution lifecycle.
- *
  * Matrix computes State, Energy executes Process, but Boundary alone persists
  * the materialized State and turns a proposed W result into durable Fields.
  */
@@ -114,12 +107,12 @@ export class BoundaryExecutionStore {
     if (part.part === "photon" && part.op === "test") return await this.registerExecution(part)
     if (part.part === "z" && part.op === "copy") return await this.selectEnergy(part)
     if ((part.part === "w+" || part.part === "w-") && part.op === "replace") {
-      return await this.commitResult(part)
+      const proposal = proposalValue(part.value)
+      return proposal ? await this.commitResult(part, proposal) : undefined
     }
     return undefined
   }
 
-  /** Persists a non-Process State without echoing another Photon. */
   private async commitState(part: Particle): Promise<null | undefined> {
     const actorId = positiveId(part.path)
     const stateName = typeof part.value === "string" ? part.value : null
@@ -145,7 +138,6 @@ export class BoundaryExecutionStore {
     return null
   }
 
-  /** Atomically persists a Process State and registers its execution identity. */
   private async registerExecution(part: Particle): Promise<null | undefined> {
     const actorId = positiveId(part.path)
     const stateName = typeof part.value === "string" ? part.value : null
@@ -165,7 +157,6 @@ export class BoundaryExecutionStore {
         if (existing.actor !== actorId || existing.process !== process.id || existing.state !== stateName) {
           throw new Error(`Process execution identity collision: ${processExecutionId}`)
         }
-        // A delayed duplicate must not move a completed actor back into its old State.
         if (existing.status !== "pending") return
       }
 
@@ -216,11 +207,13 @@ export class BoundaryExecutionStore {
     return null
   }
 
-  private async commitResult(part: Particle): Promise<BoundaryIncrementalCommit | null> {
+  private async commitResult(
+    part: Particle,
+    proposal: ProcessResultProposal,
+  ): Promise<BoundaryIncrementalCommit | null> {
     const actorId = positiveId(part.path)
-    const proposal = proposalValue(part.value)
     const energy = typeof part.from === "string" ? part.from.trim() : ""
-    if (actorId === null || !proposal || energy.length === 0) {
+    if (actorId === null || energy.length === 0) {
       throw new Error("W result requires actor path, Energy source, processExecutionId, processId and fields")
     }
 
@@ -259,34 +252,14 @@ export class BoundaryExecutionStore {
         }
       }
 
-      const fields = new Map<number, unknown>()
-      for (const [address, value] of Object.entries(proposal.fields)) {
-        const fieldId = resolveForceFieldId(address)
-        if (fieldId === null || !allowed.has(fieldId)) {
-          throw new Error(`Process ${proposal.processId} cannot write field ${address}`)
-        }
-        if (JSON.stringify(value) === undefined) throw new Error(`Field ${address} result is not serializable`)
-        fields.set(fieldId, value)
-      }
-
-      const fieldRows = await tx<FieldRow[]>`
-        SELECT id, type FROM field WHERE wimp = ${actor.wimp}
-      `
-      const fieldById = new Map(fieldRows.map((field) => [Number(field.id), field]))
-      const scalar: Record<string, unknown> = {}
-      const topology: Record<string, unknown> = {}
-
-      for (const [fieldId, value] of fields) {
-        const field = fieldById.get(fieldId)
-        if (!field) throw new Error(`Field ${fieldId} does not belong to actor ${actorId}`)
-        await tx`
-          INSERT INTO boundary_actor_field (actor, field, value_json)
-          VALUES (${actorId}, ${fieldId}, ${JSON.stringify(value)})
-          ON CONFLICT (actor, field) DO UPDATE SET value_json = excluded.value_json
-        `
-        const target = field.type === "enum" || field.type === "array" ? topology : scalar
-        target[String(fieldId)] = value
-      }
+      const fieldCommit = await commitBoundaryActorFields(
+        tx,
+        actorId,
+        actor.wimp,
+        allowed,
+        proposal.fields,
+        `Process ${proposal.processId}`,
+      )
 
       const status = part.part === "w+" ? "committed" : "failed"
       const updated = await tx<Array<{executionId: string}>>`
@@ -300,7 +273,7 @@ export class BoundaryExecutionStore {
         RETURNING execution_id AS executionId
       `
       if (updated.length !== 1) throw new Error(`Concurrent W commit for ${proposal.processExecutionId}`)
-      return {actor, scalar, topology}
+      return {actor, ...fieldCommit}
     })
 
     if (!committed) return null

--- a/boundary/execution.ts
+++ b/boundary/execution.ts
@@ -19,6 +19,11 @@ type ActorRow = {
   wimp: string
 }
 
+type StateRow = {
+  id: number
+  name: string
+}
+
 type ExecutionRow = {
   executionId: string
   actor: number
@@ -58,12 +63,6 @@ const executionValue = (value: unknown): ProcessExecutionGrant | null => {
   }
 }
 
-const claimValue = (value: unknown): ProcessExecutionClaim | null => {
-  if (!isRecord(value) || typeof value.energy !== "string" || !isProcessExecutionId(value.processExecutionId)) return null
-  const energy = value.energy.trim()
-  return energy.length > 0 ? {energy, processExecutionId: value.processExecutionId} : null
-}
-
 const proposalValue = (value: unknown): ProcessResultProposal | null => {
   if (
     !isRecord(value) ||
@@ -81,9 +80,10 @@ const proposalValue = (value: unknown): ProcessResultProposal | null => {
 }
 
 /**
- * Boundary-owned process execution handshake and canonical W-result commit.
- * Matrix owns transition computation, Energy owns execution, Boundary alone
- * turns a proposed result into durable actor fields and committed consequences.
+ * Boundary-owned State and Process execution lifecycle.
+ *
+ * Matrix computes State, Energy executes Process, but Boundary alone persists
+ * the materialized State and turns a proposed W result into durable Fields.
  */
 export class BoundaryExecutionStore {
   constructor(readonly sql: SQL) {}
@@ -110,6 +110,7 @@ export class BoundaryExecutionStore {
 
   async apply(input: ForceMessage): Promise<BoundaryIncrementalCommit | null | undefined> {
     const part = input.parts[0]
+    if (part.part === "photon" && part.op === "replace") return await this.commitState(part)
     if (part.part === "photon" && part.op === "test") return await this.registerExecution(part)
     if (part.part === "z" && part.op === "copy") return await this.selectEnergy(part)
     if ((part.part === "w+" || part.part === "w-") && part.op === "replace") {
@@ -118,17 +119,61 @@ export class BoundaryExecutionStore {
     return undefined
   }
 
-  private async registerExecution(part: Particle): Promise<null | undefined> {
+  /** Persists a non-Process State without echoing another Photon. */
+  private async commitState(part: Particle): Promise<null | undefined> {
     const actorId = positiveId(part.path)
-    const state = typeof part.value === "string" ? part.value : null
-    const processExecutionId = isProcessExecutionId(part.from) ? part.from : null
-    if (actorId === null || state === null || processExecutionId === null) return undefined
-
-    const actor = await this.actor(this.sql, actorId)
-    const process = actor ? await this.processForState(this.sql, actor.wimp, state) : null
-    if (!actor || !process) throw new Error(`Cannot register process execution for actor=${actorId} state=${state}`)
+    const stateName = typeof part.value === "string" ? part.value : null
+    if (actorId === null || stateName === null) return undefined
 
     await this.sql.begin(async (tx) => {
+      const actor = await this.actor(tx, actorId)
+      const state = actor ? await this.stateForName(tx, actor.wimp, stateName) : null
+      if (!actor || !state) throw new Error(`Cannot commit State for actor=${actorId} state=${stateName}`)
+
+      await tx`
+        INSERT INTO actor_state (actor, metaState)
+        VALUES (${actorId}, ${state.id})
+        ON CONFLICT (actor) DO UPDATE SET metaState = excluded.metaState
+      `
+      await tx`
+        UPDATE boundary_process_execution
+           SET status = ${"superseded"}
+         WHERE actor = ${actorId}
+           AND status = ${"pending"}
+      `
+    })
+    return null
+  }
+
+  /** Atomically persists a Process State and registers its execution identity. */
+  private async registerExecution(part: Particle): Promise<null | undefined> {
+    const actorId = positiveId(part.path)
+    const stateName = typeof part.value === "string" ? part.value : null
+    const processExecutionId = isProcessExecutionId(part.from) ? part.from : null
+    if (actorId === null || stateName === null || processExecutionId === null) return undefined
+
+    await this.sql.begin(async (tx) => {
+      const actor = await this.actor(tx, actorId)
+      const state = actor ? await this.stateForName(tx, actor.wimp, stateName) : null
+      const process = actor ? await this.processForState(tx, actor.wimp, stateName) : null
+      if (!actor || !state || !process) {
+        throw new Error(`Cannot register process execution for actor=${actorId} state=${stateName}`)
+      }
+
+      const existing = await this.execution(tx, processExecutionId)
+      if (existing) {
+        if (existing.actor !== actorId || existing.process !== process.id || existing.state !== stateName) {
+          throw new Error(`Process execution identity collision: ${processExecutionId}`)
+        }
+        // A delayed duplicate must not move a completed actor back into its old State.
+        if (existing.status !== "pending") return
+      }
+
+      await tx`
+        INSERT INTO actor_state (actor, metaState)
+        VALUES (${actorId}, ${state.id})
+        ON CONFLICT (actor) DO UPDATE SET metaState = excluded.metaState
+      `
       await tx`
         UPDATE boundary_process_execution
            SET status = ${"superseded"}
@@ -138,11 +183,12 @@ export class BoundaryExecutionStore {
       `
       await tx`
         INSERT INTO boundary_process_execution (execution_id, actor, process, state, status)
-        VALUES (${processExecutionId}, ${actorId}, ${process.id}, ${state}, ${"pending"})
+        VALUES (${processExecutionId}, ${actorId}, ${process.id}, ${stateName}, ${"pending"})
         ON CONFLICT (execution_id) DO NOTHING
       `
-      const existing = await this.execution(tx, processExecutionId)
-      if (!existing || existing.actor !== actorId || existing.process !== process.id || existing.state !== state) {
+
+      const inserted = await this.execution(tx, processExecutionId)
+      if (!inserted || inserted.actor !== actorId || inserted.process !== process.id || inserted.state !== stateName) {
         throw new Error(`Process execution identity collision: ${processExecutionId}`)
       }
     })
@@ -198,8 +244,9 @@ export class BoundaryExecutionStore {
 
       const actor = await this.actor(tx, actorId)
       const process = actor ? await this.processById(tx, actor.wimp, proposal.processId) : null
-      if (!actor || !process || process.state !== execution.state) {
-        throw new Error(`Process declaration changed during execution ${proposal.processExecutionId}`)
+      const currentState = actor ? await this.currentState(tx, actorId) : null
+      if (!actor || !process || process.state !== execution.state || currentState?.name !== execution.state) {
+        throw new Error(`Process declaration or State changed during execution ${proposal.processExecutionId}`)
       }
 
       const handlerName = part.part === "w+" ? "success" : "error"
@@ -296,6 +343,23 @@ export class BoundaryExecutionStore {
       SELECT id, wimp FROM actor WHERE id = ${actorId}
     `)[0]
     return actor ? {id: Number(actor.id), wimp: actor.wimp} : null
+  }
+
+  private async stateForName(sql: Database, wimp: string, name: string): Promise<StateRow | null> {
+    const state = (await sql<StateRow[]>`
+      SELECT id, name FROM state WHERE wimp = ${wimp} AND name = ${name}
+    `)[0]
+    return state ? {id: Number(state.id), name: state.name} : null
+  }
+
+  private async currentState(sql: Database, actorId: number): Promise<StateRow | null> {
+    const state = (await sql<StateRow[]>`
+      SELECT state.id, state.name
+        FROM actor_state
+        JOIN state ON state.id = actor_state.metaState
+       WHERE actor_state.actor = ${actorId}
+    `)[0]
+    return state ? {id: Number(state.id), name: state.name} : null
   }
 
   private async execution(sql: Database, processExecutionId: string): Promise<ExecutionRow | null> {

--- a/boundary/reaction.spec.ts
+++ b/boundary/reaction.spec.ts
@@ -1,0 +1,228 @@
+import {afterEach, beforeEach, describe, expect, test} from "bun:test"
+import type {ForceMessage} from "@metafor/types/force/message"
+import type {Particle} from "@metafor/types/force/particle"
+import {
+  type ReactionExecutionClaim,
+  type ReactionExecutionSignal,
+  type ReactionResultProposal,
+} from "@metafor/types/force/reaction"
+import {boundaryEntityId} from "./incremental.ts"
+import {open, type BoundaryDatabase} from "./sqlite.ts"
+
+const SOURCE = "test/reaction-source"
+const TARGET = "test/reaction-target"
+const TARGET_RESULT = boundaryEntityId(`${TARGET}/fields/1`)
+const TARGET_REACTION = boundaryEntityId(`${TARGET}/reactions/1`)
+const message = (part: Particle): ForceMessage => ({parts: [part]})
+
+describe("Boundary Reaction lifecycle", () => {
+  let boundary: BoundaryDatabase
+  let sourceActorId: number
+  let targetActorId: number
+
+  beforeEach(async () => {
+    boundary = await open(":memory:")
+    const declarations: Particle[] = [
+      {part: "inflaton", op: "add", path: `${SOURCE}/meta`, value: {name: "Source"}},
+      {part: "inflaton", op: "add", path: `${SOURCE}/fields/1`, value: {key: "value", type: "number", default: 0}},
+      {part: "inflaton", op: "add", path: `${SOURCE}/states/1`, value: {name: "idle", position: 0}},
+      {part: "inflaton", op: "test", path: SOURCE},
+      {part: "inflaton", op: "add", path: `${TARGET}/meta`, value: {name: "Target"}},
+      {part: "inflaton", op: "add", path: `${TARGET}/fields/1`, value: {key: "result", type: "number", default: 0}},
+      {part: "inflaton", op: "add", path: `${TARGET}/states/1`, value: {name: "idle", position: 0}},
+      {
+        part: "inflaton",
+        op: "add",
+        path: `${TARGET}/reactions/1`,
+        value: {
+          key: "source-change",
+          label: "Source changed",
+          cond: "() => ({meta: 'test/reaction-source', op: 'replace', path: '/context'})",
+          src: "({update}) => update({result: 2})",
+          read: ["1"],
+          write: ["1"],
+          states: ["1"],
+        },
+      },
+      {part: "inflaton", op: "test", path: TARGET},
+    ]
+    for (const part of declarations) await boundary.materialize(message(part))
+
+    const actors = await boundary.projection.sql<Array<{id: number; wimp: string}>>`
+      SELECT id, wimp FROM actor WHERE wimp IN (${SOURCE}, ${TARGET}) ORDER BY id
+    `
+    sourceActorId = Number(actors.find((actor) => actor.wimp === SOURCE)?.id)
+    targetActorId = Number(actors.find((actor) => actor.wimp === TARGET)?.id)
+    if (!sourceActorId || !targetActorId) throw new Error("Reaction actors were not materialized")
+
+    await boundary.materialize(message({part: "photon", op: "replace", path: sourceActorId, value: "idle"}))
+    await boundary.materialize(message({part: "photon", op: "replace", path: targetActorId, value: "idle"}))
+  })
+
+  afterEach(async () => {
+    await boundary.close()
+  })
+
+  const targetValue = async (): Promise<unknown> => {
+    const row = (await boundary.projection.sql<Array<{valueJson: string}>>`
+      SELECT value_json AS valueJson
+        FROM boundary_actor_field
+       WHERE actor = ${targetActorId} AND field = ${TARGET_RESULT}
+    `)[0]
+    return row ? JSON.parse(row.valueJson) as unknown : undefined
+  }
+
+  const schedule = async (): Promise<ReactionExecutionSignal> => {
+    const signals = await boundary.reaction.derive([message({
+      part: "gluon",
+      op: "replace",
+      path: sourceActorId,
+      from: "source-commit",
+      value: {fields: {"1": 1}},
+    })])
+    expect(signals).toHaveLength(1)
+    const signalPart = signals[0]!.parts[0]!
+    expect(signalPart.part).toBe("photon")
+    expect(signalPart.op).toBe("test")
+    expect(signalPart.path).toBe(targetActorId)
+    return signalPart.value as ReactionExecutionSignal
+  }
+
+  test("selects one Energy and commits declared Reaction writes", async () => {
+    const signal = await schedule()
+    expect(signal.reactionId).toBe(TARGET_REACTION)
+    expect(signal.target).toEqual({actorId: targetActorId, wimp: TARGET, state: "idle"})
+    expect(signal.source.actorId).toBe(sourceActorId)
+    expect(signal.writeFields).toEqual([[TARGET_RESULT, "result"]])
+
+    const claim: ReactionExecutionClaim = {
+      kind: "reaction-claim",
+      energy: "energy-reaction",
+      reactionExecutionId: signal.reactionExecutionId,
+    }
+    const grant = await boundary.materialize(message({part: "z", op: "test", path: targetActorId, value: claim}))
+    expect(grant?.messages).toEqual([message({
+      part: "z",
+      op: "copy",
+      path: targetActorId,
+      from: "energy-reaction",
+      value: signal,
+    })])
+
+    const losingClaim = await boundary.materialize(message({
+      part: "z",
+      op: "test",
+      path: targetActorId,
+      value: {...claim, energy: "energy-other"},
+    }))
+    expect(losingClaim).toBeNull()
+
+    const proposal: ReactionResultProposal = {
+      reactionExecutionId: signal.reactionExecutionId,
+      reactionId: signal.reactionId,
+      matched: true,
+      fields: {[String(TARGET_RESULT)]: 2},
+    }
+    const commit = await boundary.materialize(message({
+      part: "w+",
+      op: "replace",
+      path: targetActorId,
+      from: "energy-reaction",
+      value: proposal,
+    }))
+
+    expect(await targetValue()).toBe(2)
+    expect(commit?.messages[0]?.parts[0]).toEqual({
+      part: "gluon",
+      op: "replace",
+      path: targetActorId,
+      from: signal.reactionExecutionId,
+      value: {fields: {[String(TARGET_RESULT)]: 2}},
+    })
+    expect(commit?.messages[1]?.parts[0]).toEqual({
+      part: "w+",
+      op: "copy",
+      path: targetActorId,
+      from: signal.reactionExecutionId,
+      value: {
+        reactionExecutionId: signal.reactionExecutionId,
+        reactionId: signal.reactionId,
+        energy: "energy-reaction",
+        status: "committed",
+      },
+    })
+
+    expect(await boundary.materialize(message({
+      part: "w+",
+      op: "replace",
+      path: targetActorId,
+      from: "energy-reaction",
+      value: proposal,
+    }))).toBeNull()
+  })
+
+  test("records skipped filter without mutating the world", async () => {
+    const signal = await schedule()
+    const claim: ReactionExecutionClaim = {
+      kind: "reaction-claim",
+      energy: "energy-reaction",
+      reactionExecutionId: signal.reactionExecutionId,
+    }
+    await boundary.materialize(message({part: "z", op: "test", path: targetActorId, value: claim}))
+    const commit = await boundary.materialize(message({
+      part: "w-",
+      op: "replace",
+      path: targetActorId,
+      from: "energy-reaction",
+      value: {
+        reactionExecutionId: signal.reactionExecutionId,
+        reactionId: signal.reactionId,
+        matched: false,
+        fields: {},
+      } satisfies ReactionResultProposal,
+    }))
+    expect(await targetValue()).toBe(0)
+    expect(commit?.messages).toEqual([message({
+      part: "w-",
+      op: "copy",
+      path: targetActorId,
+      from: signal.reactionExecutionId,
+      value: {
+        reactionExecutionId: signal.reactionExecutionId,
+        reactionId: signal.reactionId,
+        energy: "energy-reaction",
+        status: "skipped",
+      },
+    })])
+  })
+
+  test("rejects undeclared writes and stale State", async () => {
+    const signal = await schedule()
+    const claim: ReactionExecutionClaim = {
+      kind: "reaction-claim",
+      energy: "energy-reaction",
+      reactionExecutionId: signal.reactionExecutionId,
+    }
+    await boundary.materialize(message({part: "z", op: "test", path: targetActorId, value: claim}))
+
+    await expect(boundary.materialize(message({
+      part: "w+",
+      op: "replace",
+      path: targetActorId,
+      from: "energy-reaction",
+      value: {
+        reactionExecutionId: signal.reactionExecutionId,
+        reactionId: signal.reactionId,
+        matched: true,
+        fields: {"999": 3},
+      } satisfies ReactionResultProposal,
+    }))).rejects.toThrow("cannot write field")
+    expect(await targetValue()).toBe(0)
+
+    await boundary.materialize(message({part: "photon", op: "replace", path: targetActorId, value: "idle"}))
+    const status = (await boundary.projection.sql<Array<{status: string}>>`
+      SELECT status FROM boundary_reaction_execution WHERE execution_id = ${signal.reactionExecutionId}
+    `)[0]?.status
+    expect(status).toBe("superseded")
+  })
+})

--- a/boundary/reaction.ts
+++ b/boundary/reaction.ts
@@ -1,0 +1,455 @@
+import type {ReservedSQL, SQL} from "bun"
+import type {ForceMessage} from "@metafor/types/force/message"
+import type {Particle} from "@metafor/types/force/particle"
+import {
+  REACTION_SIGNAL_KIND,
+  isReactionExecutionClaim,
+  isReactionExecutionSignal,
+  isReactionResultProposal,
+  type ReactionExecutionSignal,
+  type ReactionResultCommit,
+  type ReactionResultProposal,
+} from "@metafor/types/force/reaction"
+import type {BoundaryIncrementalCommit} from "./incremental.ts"
+import {commitBoundaryActorFields} from "./world.ts"
+
+type Database = SQL | ReservedSQL
+type JsonRecord = Record<string, unknown>
+
+type ActorStateRow = {
+  actorId: number
+  wimp: string
+  stateId: number
+  stateName: string
+}
+
+type ReactionExecutionRow = {
+  executionId: string
+  targetActor: number
+  reaction: number
+  targetState: string
+  energy: string | null
+  status: "pending" | "committed" | "skipped" | "failed" | "superseded"
+  signalJson: string
+  resultPart: "w+" | "w-" | null
+  resultJson: string | null
+}
+
+type CanonicalReaction = {
+  id: number
+  wimp: string
+  cond: string
+  update: string
+  read: number[]
+  write: number[]
+  states: number[]
+}
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const positiveId = (value: unknown): number | null =>
+  typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : null
+
+const message = (part: Particle): ForceMessage => ({parts: [part]})
+
+/**
+ * Boundary schedules Reaction candidates from committed world consequences,
+ * selects one Energy executor and commits the resulting writes through the same
+ * world writer used by Process W results.
+ */
+export class BoundaryReactionStore {
+  constructor(readonly sql: SQL) {}
+
+  async init(): Promise<void> {
+    await this.sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS boundary_reaction_execution (
+        execution_id TEXT PRIMARY KEY,
+        target_actor INTEGER NOT NULL,
+        reaction INTEGER NOT NULL,
+        target_state TEXT NOT NULL,
+        energy TEXT,
+        status TEXT NOT NULL CHECK (status IN ('pending', 'committed', 'skipped', 'failed', 'superseded')),
+        signal_json TEXT NOT NULL,
+        result_part TEXT CHECK (result_part IN ('w+', 'w-')),
+        result_json TEXT,
+        created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+        committed_at INTEGER,
+        FOREIGN KEY (target_actor) REFERENCES actor (id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS boundary_reaction_target_status
+        ON boundary_reaction_execution (target_actor, status);
+    `)
+  }
+
+  async apply(input: ForceMessage): Promise<BoundaryIncrementalCommit | null | undefined> {
+    const part = input.parts[0]
+    if (part.part === "photon" && (part.op === "replace" || part.op === "test") && typeof part.value === "string") {
+      await this.supersedeForStateChange(part)
+      return undefined
+    }
+    if (part.part === "z" && part.op === "test" && isReactionExecutionClaim(part.value)) {
+      return await this.selectEnergy(part)
+    }
+    if ((part.part === "w+" || part.part === "w-") && part.op === "replace" && isReactionResultProposal(part.value)) {
+      return await this.commitResult(part, part.value)
+    }
+    return undefined
+  }
+
+  /** Builds candidate signals only from consequences already committed by Boundary. */
+  async derive(committedMessages: readonly ForceMessage[]): Promise<ForceMessage[]> {
+    const signals: ForceMessage[] = []
+    for (const committed of committedMessages) {
+      const part = committed.parts[0]
+      if ((part.part !== "gluon" && part.part !== "higgs") ||
+          (part.op !== "add" && part.op !== "replace" && part.op !== "remove")) continue
+      const sourceActorId = positiveId(part.path)
+      if (sourceActorId === null) continue
+      signals.push(...await this.deriveForFieldConsequence(sourceActorId, part))
+    }
+    return signals
+  }
+
+  private async deriveForFieldConsequence(sourceActorId: number, part: Particle): Promise<ForceMessage[]> {
+    const source = await this.actorState(this.sql, sourceActorId)
+    if (!source) return []
+
+    const targets = await this.sql<ActorStateRow[]>`
+      SELECT actor.id AS actorId,
+             actor.wimp AS wimp,
+             state.id AS stateId,
+             state.name AS stateName
+        FROM actor
+        JOIN actor_state ON actor_state.actor = actor.id
+        JOIN state ON state.id = actor_state.metaState
+       WHERE actor.id <> ${sourceActorId}
+       ORDER BY actor.id
+    `
+    const result: ForceMessage[] = []
+    const reactionCache = new Map<string, CanonicalReaction[]>()
+
+    for (const rawTarget of targets) {
+      const target: ActorStateRow = {
+        actorId: Number(rawTarget.actorId),
+        wimp: rawTarget.wimp,
+        stateId: Number(rawTarget.stateId),
+        stateName: rawTarget.stateName,
+      }
+      let reactions = reactionCache.get(target.wimp)
+      if (!reactions) {
+        reactions = await this.reactions(this.sql, target.wimp)
+        reactionCache.set(target.wimp, reactions)
+      }
+      if (reactions.length === 0) continue
+
+      const value = await this.actorValues(this.sql, target.actorId, target.wimp)
+      const fieldKeys = await this.fieldKeys(this.sql, target.wimp)
+
+      for (const reaction of reactions) {
+        if (!reaction.states.includes(target.stateId)) continue
+        const reactionExecutionId = crypto.randomUUID()
+        const writeFields: Array<[number, string]> = []
+        for (const fieldId of reaction.write) {
+          const key = fieldKeys.get(fieldId)
+          if (key) writeFields.push([fieldId, key])
+        }
+        if (writeFields.length !== reaction.write.length) {
+          throw new Error(`Reaction ${reaction.id} references missing write Fields`)
+        }
+
+        const signal: ReactionExecutionSignal = {
+          kind: REACTION_SIGNAL_KIND,
+          reactionExecutionId,
+          reactionId: reaction.id,
+          target: {
+            actorId: target.actorId,
+            wimp: target.wimp,
+            state: target.stateName,
+          },
+          source: {
+            actorId: source.actorId,
+            wimp: source.wimp,
+            timestamp: Date.now(),
+            part: {
+              op: part.op,
+              path: "/context",
+              ...(part.from === undefined ? {} : {from: part.from}),
+              ...(part.value === undefined ? {} : {value: structuredClone(part.value)}),
+            },
+          },
+          value,
+          writeFields,
+          cond: reaction.cond,
+          update: reaction.update,
+        }
+
+        await this.sql`
+          INSERT INTO boundary_reaction_execution
+            (execution_id, target_actor, reaction, target_state, status, signal_json)
+          VALUES (${reactionExecutionId}, ${target.actorId}, ${reaction.id}, ${target.stateName}, ${"pending"}, ${JSON.stringify(signal)})
+        `
+        result.push(message({
+          part: "photon",
+          op: "test",
+          path: target.actorId,
+          from: reactionExecutionId,
+          value: signal,
+        }))
+      }
+    }
+    return result
+  }
+
+  private async selectEnergy(part: Particle): Promise<BoundaryIncrementalCommit | null> {
+    const claim = part.value
+    if (!isReactionExecutionClaim(claim)) return null
+    const energy = claim.energy.trim()
+
+    const selected = await this.sql.begin(async (tx) => {
+      const execution = await this.execution(tx, claim.reactionExecutionId)
+      if (!execution || execution.status !== "pending") return null
+      if (execution.energy !== null && execution.energy !== energy) return null
+
+      await tx`
+        UPDATE boundary_reaction_execution
+           SET energy = COALESCE(energy, ${energy})
+         WHERE execution_id = ${claim.reactionExecutionId}
+           AND status = ${"pending"}
+           AND (energy IS NULL OR energy = ${energy})
+      `
+      const signal = JSON.parse(execution.signalJson) as unknown
+      if (!isReactionExecutionSignal(signal)) {
+        throw new Error(`Invalid stored Reaction signal ${claim.reactionExecutionId}`)
+      }
+      return signal
+    })
+    if (!selected) return null
+
+    return {
+      rootSrc: selected.target.wimp,
+      messages: [message({
+        part: "z",
+        op: "copy",
+        path: selected.target.actorId,
+        from: energy,
+        value: selected,
+      })],
+    }
+  }
+
+  private async commitResult(
+    part: Particle,
+    proposal: ReactionResultProposal,
+  ): Promise<BoundaryIncrementalCommit | null> {
+    const targetActorId = positiveId(part.path)
+    const energy = typeof part.from === "string" ? part.from.trim() : ""
+    if (targetActorId === null || energy.length === 0) {
+      throw new Error("Reaction W result requires target Actor and Energy source")
+    }
+
+    const resultJson = JSON.stringify(proposal)
+    const committed = await this.sql.begin(async (tx) => {
+      const execution = await this.execution(tx, proposal.reactionExecutionId)
+      if (!execution) throw new Error(`Unknown Reaction execution ${proposal.reactionExecutionId}`)
+      if (execution.status !== "pending") {
+        if (
+          execution.targetActor === targetActorId &&
+          execution.reaction === proposal.reactionId &&
+          execution.energy === energy &&
+          execution.resultPart === part.part &&
+          execution.resultJson === resultJson
+        ) return null
+        throw new Error(`Reaction execution ${proposal.reactionExecutionId} is already ${execution.status}`)
+      }
+      if (execution.targetActor !== targetActorId || execution.reaction !== proposal.reactionId || execution.energy !== energy) {
+        throw new Error(`Reaction result does not match selected execution ${proposal.reactionExecutionId}`)
+      }
+
+      const signalValue = JSON.parse(execution.signalJson) as unknown
+      if (!isReactionExecutionSignal(signalValue)) throw new Error(`Invalid Reaction signal ${proposal.reactionExecutionId}`)
+      const signal = signalValue
+      const target = await this.actorState(tx, targetActorId)
+      const reaction = target ? await this.reactionById(tx, target.wimp, proposal.reactionId) : null
+      if (!target || !reaction || target.stateName !== execution.targetState || target.stateName !== signal.target.state ||
+          !reaction.states.includes(target.stateId)) {
+        throw new Error(`Reaction declaration or State changed during execution ${proposal.reactionExecutionId}`)
+      }
+
+      if (part.part === "w+" && (!proposal.matched || proposal.error !== undefined)) {
+        throw new Error(`Successful Reaction result must be matched and error-free`)
+      }
+      if (part.part === "w-" && Object.keys(proposal.fields).length > 0) {
+        throw new Error(`Failed or skipped Reaction cannot commit Fields`)
+      }
+
+      const allowed = new Set(reaction.write)
+      const fieldCommit = part.part === "w+"
+        ? await commitBoundaryActorFields(
+            tx,
+            targetActorId,
+            target.wimp,
+            allowed,
+            proposal.fields,
+            `Reaction ${proposal.reactionId}`,
+          )
+        : {scalar: {}, topology: {}}
+
+      const status: ReactionExecutionRow["status"] = part.part === "w+"
+        ? "committed"
+        : proposal.matched || proposal.error !== undefined
+          ? "failed"
+          : "skipped"
+      const updated = await tx<Array<{executionId: string}>>`
+        UPDATE boundary_reaction_execution
+           SET status = ${status},
+               result_part = ${part.part},
+               result_json = ${resultJson},
+               committed_at = unixepoch()
+         WHERE execution_id = ${proposal.reactionExecutionId}
+           AND status = ${"pending"}
+        RETURNING execution_id AS executionId
+      `
+      if (updated.length !== 1) throw new Error(`Concurrent Reaction commit ${proposal.reactionExecutionId}`)
+      return {target, status, ...fieldCommit}
+    })
+
+    if (!committed) return null
+    const consequences: ForceMessage[] = []
+    if (Object.keys(committed.scalar).length > 0) {
+      consequences.push(message({
+        part: "gluon",
+        op: "replace",
+        path: targetActorId,
+        from: proposal.reactionExecutionId,
+        value: {fields: committed.scalar},
+      }))
+    }
+    if (Object.keys(committed.topology).length > 0) {
+      consequences.push(message({
+        part: "higgs",
+        op: "replace",
+        path: targetActorId,
+        from: proposal.reactionExecutionId,
+        value: {fields: committed.topology},
+      }))
+    }
+    const acknowledgement: ReactionResultCommit = {
+      reactionExecutionId: proposal.reactionExecutionId,
+      reactionId: proposal.reactionId,
+      energy,
+      status: committed.status === "committed" ? "committed" : committed.status === "skipped" ? "skipped" : "failed",
+    }
+    consequences.push(message({
+      part: part.part,
+      op: "copy",
+      path: targetActorId,
+      from: proposal.reactionExecutionId,
+      value: acknowledgement,
+    }))
+    return {rootSrc: committed.target.wimp, messages: consequences}
+  }
+
+  private async supersedeForStateChange(part: Particle): Promise<void> {
+    const actorId = positiveId(part.path)
+    if (actorId === null) return
+    await this.sql`
+      UPDATE boundary_reaction_execution
+         SET status = ${"superseded"}
+       WHERE target_actor = ${actorId}
+         AND status = ${"pending"}
+    `
+  }
+
+  private async actorState(sql: Database, actorId: number): Promise<ActorStateRow | null> {
+    const row = (await sql<ActorStateRow[]>`
+      SELECT actor.id AS actorId,
+             actor.wimp AS wimp,
+             state.id AS stateId,
+             state.name AS stateName
+        FROM actor
+        JOIN actor_state ON actor_state.actor = actor.id
+        JOIN state ON state.id = actor_state.metaState
+       WHERE actor.id = ${actorId}
+    `)[0]
+    return row ? {
+      actorId: Number(row.actorId),
+      wimp: row.wimp,
+      stateId: Number(row.stateId),
+      stateName: row.stateName,
+    } : null
+  }
+
+  private async actorValues(sql: Database, actorId: number, wimp: string): Promise<Record<string, unknown>> {
+    const value: Record<string, unknown> = {}
+    for (const row of await sql<Array<{key: string; valueJson: string}>>`
+      SELECT field.key AS key,
+             boundary_actor_field.value_json AS valueJson
+        FROM field
+        JOIN boundary_actor_field ON boundary_actor_field.field = field.id
+       WHERE boundary_actor_field.actor = ${actorId}
+         AND field.wimp = ${wimp}
+       ORDER BY field.local_id, field.id
+    `) value[row.key] = JSON.parse(row.valueJson) as unknown
+    return value
+  }
+
+  private async fieldKeys(sql: Database, wimp: string): Promise<Map<number, string>> {
+    const rows = await sql<Array<{id: number; key: string}>>`
+      SELECT id, key FROM field WHERE wimp = ${wimp}
+    `
+    return new Map(rows.map((row) => [Number(row.id), row.key]))
+  }
+
+  private async execution(sql: Database, executionId: string): Promise<ReactionExecutionRow | null> {
+    const row = (await sql<ReactionExecutionRow[]>`
+      SELECT execution_id AS executionId,
+             target_actor AS targetActor,
+             reaction,
+             target_state AS targetState,
+             energy,
+             status,
+             signal_json AS signalJson,
+             result_part AS resultPart,
+             result_json AS resultJson
+        FROM boundary_reaction_execution
+       WHERE execution_id = ${executionId}
+    `)[0]
+    return row ? {
+      ...row,
+      targetActor: Number(row.targetActor),
+      reaction: Number(row.reaction),
+    } : null
+  }
+
+  private async reactionById(sql: Database, wimp: string, reactionId: number): Promise<CanonicalReaction | null> {
+    for (const reaction of await this.reactions(sql, wimp)) if (reaction.id === reactionId) return reaction
+    return null
+  }
+
+  private async reactions(sql: Database, wimp: string): Promise<CanonicalReaction[]> {
+    const result: CanonicalReaction[] = []
+    for (const row of await sql<Array<{canonicalJson: string}>>`
+      SELECT canonical_json AS canonicalJson
+        FROM boundary_declaration_entity
+       WHERE src = ${wimp} AND section = ${"reactions"}
+       ORDER BY CAST(local_id AS INTEGER)
+    `) {
+      const value = JSON.parse(row.canonicalJson) as unknown
+      if (!isRecord(value) || positiveId(value.id) === null || typeof value.cond !== "string" || typeof value.src !== "string") continue
+      const numbers = (items: unknown): number[] => Array.isArray(items)
+        ? items.filter((item): item is number => positiveId(item) !== null)
+        : []
+      result.push({
+        id: value.id as number,
+        wimp,
+        cond: value.cond,
+        update: value.src,
+        read: numbers(value.read),
+        write: numbers(value.write),
+        states: numbers(value.states),
+      })
+    }
+    return result
+  }
+}

--- a/boundary/server.ts
+++ b/boundary/server.ts
@@ -25,14 +25,16 @@ force.onImpulse = async (message) => {
   const part = message.parts[0]
   if (part.part === "z" && part.op === "test") {
     const request = parseForceReplayPath(part.path)
-    if (request?.domain === "matrix") {
-      await publishMatrixRuntime()
+    if (request) {
+      if (request.domain === "matrix") {
+        await publishMatrixRuntime()
+        return
+      }
+      if (request.domain === "energy" || request.domain === "bulk") {
+        for (const replay of await boundary.replay()) force.impulse(replay)
+      }
       return
     }
-    if (request && (request.domain === "energy" || request.domain === "bulk")) {
-      for (const replay of await boundary.replay()) force.impulse(replay)
-    }
-    return
   }
 
   const commit = await boundary.materialize(message)

--- a/boundary/sqlite.ts
+++ b/boundary/sqlite.ts
@@ -7,6 +7,7 @@ import {BoundaryTopologySqlite} from "@boundary/topology/sqlite"
 import type {ForceMessage} from "@metafor/types/force/message"
 import {BoundaryIncrementalStore, type BoundaryIncrementalCommit} from "./incremental.ts"
 import {BoundaryExecutionStore} from "./execution.ts"
+import {initBoundaryStateDeclarations} from "./state-declaration.ts"
 import {matrixRuntime} from "./runtime/matrix.ts"
 
 export const open = async (filename?: string) => {
@@ -27,6 +28,7 @@ export const open = async (filename?: string) => {
   const wimp = await BoundaryWimpSqlite.open(sql)
   const projection = new BoundaryIncrementalStore(sql)
   await projection.init()
+  await initBoundaryStateDeclarations(sql)
   const execution = new BoundaryExecutionStore(sql)
   await execution.init()
   let absorbQueue: Promise<unknown> = Promise.resolve()

--- a/boundary/sqlite.ts
+++ b/boundary/sqlite.ts
@@ -7,6 +7,7 @@ import {BoundaryTopologySqlite} from "@boundary/topology/sqlite"
 import type {ForceMessage} from "@metafor/types/force/message"
 import {BoundaryIncrementalStore, type BoundaryIncrementalCommit} from "./incremental.ts"
 import {BoundaryExecutionStore} from "./execution.ts"
+import {BoundaryReactionStore} from "./reaction.ts"
 import {initBoundaryStateDeclarations} from "./state-declaration.ts"
 import {matrixRuntime} from "./runtime/matrix.ts"
 
@@ -31,12 +32,25 @@ export const open = async (filename?: string) => {
   await initBoundaryStateDeclarations(sql)
   const execution = new BoundaryExecutionStore(sql)
   await execution.init()
+  const reaction = new BoundaryReactionStore(sql)
+  await reaction.init()
   let absorbQueue: Promise<unknown> = Promise.resolve()
 
   const materialize = (message: ForceMessage): Promise<BoundaryIncrementalCommit | null> => {
     const task = absorbQueue.then(async () => {
       const executionCommit = await execution.apply(message)
-      return executionCommit === undefined ? await projection.apply(message) : executionCommit
+      const reactionCommit = await reaction.apply(message)
+      const commit = executionCommit !== undefined
+        ? executionCommit
+        : reactionCommit !== undefined
+          ? reactionCommit
+          : await projection.apply(message)
+      if (!commit) return null
+
+      const reactionSignals = await reaction.derive(commit.messages)
+      return reactionSignals.length === 0
+        ? commit
+        : {...commit, messages: [...commit.messages, ...reactionSignals]}
     })
     absorbQueue = task.then(() => undefined, () => undefined)
     return task
@@ -48,6 +62,7 @@ export const open = async (filename?: string) => {
     topology,
     projection,
     execution,
+    reaction,
     replay: () => projection.replay(),
     materialize,
     matrixRuntime: () => matrixRuntime(sql),

--- a/boundary/state-declaration.ts
+++ b/boundary/state-declaration.ts
@@ -1,0 +1,76 @@
+import type {SQL} from "bun"
+
+/**
+ * Keeps the relational `state` table aligned with incremental State declarations.
+ *
+ * `boundary_declaration_entity` remains the declaration source of truth. The
+ * relational row exists so runtime `actor_state` can retain a foreign-keyed
+ * canonical State. Triggers run in the same SQLite transaction as declaration
+ * insert/update/remove; they do not create another declaration store.
+ */
+export async function initBoundaryStateDeclarations(sql: SQL): Promise<void> {
+  await sql.unsafe(`
+    INSERT INTO state (id, wimp, local_id, name, position)
+    SELECT
+      CAST(json_extract(canonical_json, '$.id') AS INTEGER),
+      src,
+      CAST(local_id AS INTEGER),
+      CAST(json_extract(canonical_json, '$.name') AS TEXT),
+      CAST(COALESCE(json_extract(canonical_json, '$.position'), local_id) AS INTEGER)
+    FROM boundary_declaration_entity
+    WHERE section = 'states'
+      AND json_type(canonical_json, '$.id') = 'integer'
+      AND json_type(canonical_json, '$.name') = 'text'
+    ON CONFLICT(id) DO UPDATE SET
+      wimp = excluded.wimp,
+      local_id = excluded.local_id,
+      name = excluded.name,
+      position = excluded.position;
+
+    CREATE TRIGGER IF NOT EXISTS boundary_state_declaration_insert
+    AFTER INSERT ON boundary_declaration_entity
+    WHEN NEW.section = 'states'
+    BEGIN
+      INSERT INTO state (id, wimp, local_id, name, position)
+      VALUES (
+        CAST(json_extract(NEW.canonical_json, '$.id') AS INTEGER),
+        NEW.src,
+        CAST(NEW.local_id AS INTEGER),
+        CAST(json_extract(NEW.canonical_json, '$.name') AS TEXT),
+        CAST(COALESCE(json_extract(NEW.canonical_json, '$.position'), NEW.local_id) AS INTEGER)
+      )
+      ON CONFLICT(id) DO UPDATE SET
+        wimp = excluded.wimp,
+        local_id = excluded.local_id,
+        name = excluded.name,
+        position = excluded.position;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS boundary_state_declaration_update
+    AFTER UPDATE OF canonical_json, src, local_id, section ON boundary_declaration_entity
+    WHEN NEW.section = 'states'
+    BEGIN
+      INSERT INTO state (id, wimp, local_id, name, position)
+      VALUES (
+        CAST(json_extract(NEW.canonical_json, '$.id') AS INTEGER),
+        NEW.src,
+        CAST(NEW.local_id AS INTEGER),
+        CAST(json_extract(NEW.canonical_json, '$.name') AS TEXT),
+        CAST(COALESCE(json_extract(NEW.canonical_json, '$.position'), NEW.local_id) AS INTEGER)
+      )
+      ON CONFLICT(id) DO UPDATE SET
+        wimp = excluded.wimp,
+        local_id = excluded.local_id,
+        name = excluded.name,
+        position = excluded.position;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS boundary_state_declaration_delete
+    AFTER DELETE ON boundary_declaration_entity
+    WHEN OLD.section = 'states'
+    BEGIN
+      DELETE FROM state
+       WHERE id = CAST(json_extract(OLD.canonical_json, '$.id') AS INTEGER);
+    END;
+  `)
+}

--- a/boundary/state-declaration.ts
+++ b/boundary/state-declaration.ts
@@ -1,71 +1,112 @@
 import type {SQL} from "bun"
 
+type StoredStateDeclaration = {
+  src: string
+  localId: string
+  canonicalJson: string
+}
+
+type CanonicalState = {
+  id: number
+  name: string
+  position: number
+}
+
+const canonicalState = (row: StoredStateDeclaration): CanonicalState | null => {
+  const value = JSON.parse(row.canonicalJson) as unknown
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null
+  const state = value as Record<string, unknown>
+  if (
+    typeof state.id !== "number" ||
+    !Number.isSafeInteger(state.id) ||
+    state.id <= 0 ||
+    typeof state.name !== "string" ||
+    state.name.trim().length === 0
+  ) return null
+
+  const localPosition = Number(row.localId)
+  const position = typeof state.position === "number" && Number.isSafeInteger(state.position)
+    ? state.position
+    : localPosition
+  if (!Number.isSafeInteger(position) || position < 0) return null
+  return {id: state.id, name: state.name, position}
+}
+
 /**
- * Keeps the relational `state` table aligned with incremental State declarations.
+ * Keeps the relational `state` projection aligned with incremental declarations.
  *
  * `boundary_declaration_entity` remains the declaration source of truth. The
- * relational row exists so runtime `actor_state` can retain a foreign-keyed
- * canonical State. Triggers run in the same SQLite transaction as declaration
- * insert/update/remove; they do not create another declaration store.
+ * relational row only gives `actor_state` a foreign-keyed canonical identity.
+ * Trigger work runs inside the same SQLite statement/transaction that changes
+ * the declaration, so an invalid State cannot leave the two projections split.
  */
 export async function initBoundaryStateDeclarations(sql: SQL): Promise<void> {
-  await sql.unsafe(`
-    INSERT INTO state (id, wimp, local_id, name, position)
-    SELECT
-      CAST(json_extract(canonical_json, '$.id') AS INTEGER),
-      src,
-      CAST(local_id AS INTEGER),
-      CAST(json_extract(canonical_json, '$.name') AS TEXT),
-      CAST(COALESCE(json_extract(canonical_json, '$.position'), local_id) AS INTEGER)
-    FROM boundary_declaration_entity
-    WHERE section = 'states'
-      AND json_type(canonical_json, '$.id') = 'integer'
-      AND json_type(canonical_json, '$.name') = 'text'
-    ON CONFLICT(id) DO UPDATE SET
-      wimp = excluded.wimp,
-      local_id = excluded.local_id,
-      name = excluded.name,
-      position = excluded.position;
+  const existing = await sql<StoredStateDeclaration[]>`
+    SELECT src, local_id AS localId, canonical_json AS canonicalJson
+      FROM boundary_declaration_entity
+     WHERE section = ${"states"}
+     ORDER BY rowid
+  `
+  for (const row of existing) {
+    const state = canonicalState(row)
+    if (!state) continue
+    await sql`
+      INSERT INTO state (id, wimp, local_id, name, position)
+      VALUES (${state.id}, ${row.src}, ${Number(row.localId)}, ${state.name}, ${state.position})
+      ON CONFLICT (id) DO UPDATE SET
+        wimp = excluded.wimp,
+        local_id = excluded.local_id,
+        name = excluded.name,
+        position = excluded.position
+    `
+  }
 
-    CREATE TRIGGER IF NOT EXISTS boundary_state_declaration_insert
+  await sql.unsafe(`
+    DROP TRIGGER IF EXISTS boundary_state_declaration_insert;
+    DROP TRIGGER IF EXISTS boundary_state_declaration_update;
+    DROP TRIGGER IF EXISTS boundary_state_declaration_delete;
+
+    CREATE TRIGGER boundary_state_declaration_insert
     AFTER INSERT ON boundary_declaration_entity
     WHEN NEW.section = 'states'
     BEGIN
-      INSERT INTO state (id, wimp, local_id, name, position)
+      INSERT OR IGNORE INTO state (id, wimp, local_id, name, position)
       VALUES (
         CAST(json_extract(NEW.canonical_json, '$.id') AS INTEGER),
         NEW.src,
         CAST(NEW.local_id AS INTEGER),
         CAST(json_extract(NEW.canonical_json, '$.name') AS TEXT),
         CAST(COALESCE(json_extract(NEW.canonical_json, '$.position'), NEW.local_id) AS INTEGER)
-      )
-      ON CONFLICT(id) DO UPDATE SET
-        wimp = excluded.wimp,
-        local_id = excluded.local_id,
-        name = excluded.name,
-        position = excluded.position;
+      );
+      UPDATE state
+         SET wimp = NEW.src,
+             local_id = CAST(NEW.local_id AS INTEGER),
+             name = CAST(json_extract(NEW.canonical_json, '$.name') AS TEXT),
+             position = CAST(COALESCE(json_extract(NEW.canonical_json, '$.position'), NEW.local_id) AS INTEGER)
+       WHERE id = CAST(json_extract(NEW.canonical_json, '$.id') AS INTEGER);
     END;
 
-    CREATE TRIGGER IF NOT EXISTS boundary_state_declaration_update
+    CREATE TRIGGER boundary_state_declaration_update
     AFTER UPDATE OF canonical_json, src, local_id, section ON boundary_declaration_entity
     WHEN NEW.section = 'states'
     BEGIN
-      INSERT INTO state (id, wimp, local_id, name, position)
+      INSERT OR IGNORE INTO state (id, wimp, local_id, name, position)
       VALUES (
         CAST(json_extract(NEW.canonical_json, '$.id') AS INTEGER),
         NEW.src,
         CAST(NEW.local_id AS INTEGER),
         CAST(json_extract(NEW.canonical_json, '$.name') AS TEXT),
         CAST(COALESCE(json_extract(NEW.canonical_json, '$.position'), NEW.local_id) AS INTEGER)
-      )
-      ON CONFLICT(id) DO UPDATE SET
-        wimp = excluded.wimp,
-        local_id = excluded.local_id,
-        name = excluded.name,
-        position = excluded.position;
+      );
+      UPDATE state
+         SET wimp = NEW.src,
+             local_id = CAST(NEW.local_id AS INTEGER),
+             name = CAST(json_extract(NEW.canonical_json, '$.name') AS TEXT),
+             position = CAST(COALESCE(json_extract(NEW.canonical_json, '$.position'), NEW.local_id) AS INTEGER)
+       WHERE id = CAST(json_extract(NEW.canonical_json, '$.id') AS INTEGER);
     END;
 
-    CREATE TRIGGER IF NOT EXISTS boundary_state_declaration_delete
+    CREATE TRIGGER boundary_state_declaration_delete
     AFTER DELETE ON boundary_declaration_entity
     WHEN OLD.section = 'states'
     BEGIN

--- a/boundary/state-declaration.ts
+++ b/boundary/state-declaration.ts
@@ -37,8 +37,7 @@ const canonicalState = (row: StoredStateDeclaration): CanonicalState | null => {
  *
  * `boundary_declaration_entity` remains the declaration source of truth. The
  * relational row only gives `actor_state` a foreign-keyed canonical identity.
- * Trigger work runs inside the same SQLite statement/transaction that changes
- * the declaration, so an invalid State cannot leave the two projections split.
+ * Triggers execute in the same SQLite transaction as declaration changes.
  */
 export async function initBoundaryStateDeclarations(sql: SQL): Promise<void> {
   const existing = await sql<StoredStateDeclaration[]>`
@@ -61,11 +60,11 @@ export async function initBoundaryStateDeclarations(sql: SQL): Promise<void> {
     `
   }
 
-  await sql.unsafe(`
-    DROP TRIGGER IF EXISTS boundary_state_declaration_insert;
-    DROP TRIGGER IF EXISTS boundary_state_declaration_update;
-    DROP TRIGGER IF EXISTS boundary_state_declaration_delete;
+  await sql.unsafe("DROP TRIGGER IF EXISTS boundary_state_declaration_insert")
+  await sql.unsafe("DROP TRIGGER IF EXISTS boundary_state_declaration_update")
+  await sql.unsafe("DROP TRIGGER IF EXISTS boundary_state_declaration_delete")
 
+  await sql.unsafe(`
     CREATE TRIGGER boundary_state_declaration_insert
     AFTER INSERT ON boundary_declaration_entity
     WHEN NEW.section = 'states'
@@ -84,8 +83,10 @@ export async function initBoundaryStateDeclarations(sql: SQL): Promise<void> {
              name = CAST(json_extract(NEW.canonical_json, '$.name') AS TEXT),
              position = CAST(COALESCE(json_extract(NEW.canonical_json, '$.position'), NEW.local_id) AS INTEGER)
        WHERE id = CAST(json_extract(NEW.canonical_json, '$.id') AS INTEGER);
-    END;
+    END
+  `)
 
+  await sql.unsafe(`
     CREATE TRIGGER boundary_state_declaration_update
     AFTER UPDATE OF canonical_json, src, local_id, section ON boundary_declaration_entity
     WHEN NEW.section = 'states'
@@ -104,14 +105,16 @@ export async function initBoundaryStateDeclarations(sql: SQL): Promise<void> {
              name = CAST(json_extract(NEW.canonical_json, '$.name') AS TEXT),
              position = CAST(COALESCE(json_extract(NEW.canonical_json, '$.position'), NEW.local_id) AS INTEGER)
        WHERE id = CAST(json_extract(NEW.canonical_json, '$.id') AS INTEGER);
-    END;
+    END
+  `)
 
+  await sql.unsafe(`
     CREATE TRIGGER boundary_state_declaration_delete
     AFTER DELETE ON boundary_declaration_entity
     WHEN OLD.section = 'states'
     BEGIN
       DELETE FROM state
        WHERE id = CAST(json_extract(OLD.canonical_json, '$.id') AS INTEGER);
-    END;
+    END
   `)
 }

--- a/boundary/state.spec.ts
+++ b/boundary/state.spec.ts
@@ -1,0 +1,134 @@
+import {afterEach, beforeEach, describe, expect, test} from "bun:test"
+import type {ForceMessage} from "@metafor/types/force/message"
+import type {Particle} from "@metafor/types/force/particle"
+import {boundaryEntityId} from "./incremental.ts"
+import {open, type BoundaryDatabase} from "./sqlite.ts"
+
+const ROOT = "test/state"
+const PROCESS = boundaryEntityId(`${ROOT}/processes/1`)
+const OUTPUT = boundaryEntityId(`${ROOT}/fields/1`)
+const message = (part: Particle): ForceMessage => ({parts: [part]})
+
+describe("Boundary canonical State", () => {
+  let boundary: BoundaryDatabase
+  let actorId: number
+
+  beforeEach(async () => {
+    boundary = await open(":memory:")
+    const declarations: Particle[] = [
+      {part: "inflaton", op: "add", path: `${ROOT}/meta`, value: {name: "State"}},
+      {part: "inflaton", op: "add", path: `${ROOT}/fields/1`, value: {key: "output", type: "number", default: 0}},
+      {part: "inflaton", op: "add", path: `${ROOT}/states/1`, value: {name: "idle", position: 0}},
+      {part: "inflaton", op: "add", path: `${ROOT}/states/2`, value: {name: "ready", position: 1}},
+      {part: "inflaton", op: "add", path: `${ROOT}/states/3`, value: {name: "complete", position: 2}},
+      {
+        part: "inflaton",
+        op: "add",
+        path: `${ROOT}/processes/1`,
+        value: {
+          key: "ready",
+          type: "action",
+          env: ["server"],
+          action: {src: "./ready.ts", read: []},
+          success: {src: "({update}) => update({output: 2})", read: ["1"], write: ["1"]},
+        },
+      },
+      {part: "inflaton", op: "test", path: ROOT},
+    ]
+    for (const part of declarations) await boundary.materialize(message(part))
+    const actor = (await boundary.projection.sql<Array<{id: number}>>`
+      SELECT id FROM actor WHERE wimp = ${ROOT} ORDER BY id LIMIT 1
+    `)[0]
+    if (!actor) throw new Error("Root actor was not materialized")
+    actorId = Number(actor.id)
+  })
+
+  afterEach(async () => {
+    await boundary.close()
+  })
+
+  const stateName = async (): Promise<string | null> => {
+    const row = (await boundary.projection.sql<Array<{name: string}>>`
+      SELECT state.name
+        FROM actor_state
+        JOIN state ON state.id = actor_state.metaState
+       WHERE actor_state.actor = ${actorId}
+    `)[0]
+    return row?.name ?? null
+  }
+
+  test("persists non-Process Photon and rebuilds Matrix from the canonical State", async () => {
+    await boundary.materialize(message({part: "photon", op: "replace", path: actorId, value: "idle"}))
+    expect(await stateName()).toBe("idle")
+
+    const snapshot = await boundary.matrixRuntime()
+    expect(snapshot.data.stateNames).toEqual([["idle", "ready", "complete"]])
+    expect(snapshot.data.branes[0]?.state).toBe(0)
+
+    await expect(boundary.materialize(message({
+      part: "photon",
+      op: "replace",
+      path: actorId,
+      value: "missing",
+    }))).rejects.toThrow("Cannot commit State")
+    expect(await stateName()).toBe("idle")
+  })
+
+  test("persists Process State atomically with execution identity", async () => {
+    const processExecutionId = "state-execution"
+    await boundary.materialize(message({
+      part: "photon",
+      op: "test",
+      path: actorId,
+      from: processExecutionId,
+      value: "ready",
+    }))
+
+    expect(await stateName()).toBe("ready")
+    const execution = (await boundary.projection.sql<Array<{
+      actor: number
+      process: number
+      state: string
+      status: string
+    }>>`
+      SELECT actor, process, state, status
+        FROM boundary_process_execution
+       WHERE execution_id = ${processExecutionId}
+    `)[0]
+    expect(execution).toEqual({actor: actorId, process: PROCESS, state: "ready", status: "pending"})
+    expect((await boundary.matrixRuntime()).data.branes[0]?.state).toBe(1)
+  })
+
+  test("supersedes stale Process and delayed duplicate cannot restore its State", async () => {
+    const processExecutionId = "state-stale"
+    const processPhoton: Particle = {
+      part: "photon",
+      op: "test",
+      path: actorId,
+      from: processExecutionId,
+      value: "ready",
+    }
+    await boundary.materialize(message(processPhoton))
+    await boundary.materialize(message({part: "photon", op: "replace", path: actorId, value: "complete"}))
+
+    expect(await stateName()).toBe("complete")
+    expect((await boundary.projection.sql<Array<{status: string}>>`
+      SELECT status FROM boundary_process_execution WHERE execution_id = ${processExecutionId}
+    `)[0]?.status).toBe("superseded")
+
+    await boundary.materialize(message(processPhoton))
+    expect(await stateName()).toBe("complete")
+
+    await expect(boundary.materialize(message({
+      part: "w+",
+      op: "replace",
+      path: actorId,
+      from: "energy-stale",
+      value: {
+        processExecutionId,
+        processId: PROCESS,
+        fields: {[String(OUTPUT)]: 2},
+      },
+    }))).rejects.toThrow("already superseded")
+  })
+})

--- a/boundary/world.ts
+++ b/boundary/world.ts
@@ -1,0 +1,60 @@
+import type {ReservedSQL, SQL} from "bun"
+import {resolveForceFieldId} from "@metafor/types/force/fields"
+
+type Database = SQL | ReservedSQL
+
+type FieldRow = {
+  id: number
+  type: string
+}
+
+export type BoundaryFieldCommit = {
+  scalar: Record<string, unknown>
+  topology: Record<string, unknown>
+}
+
+/**
+ * The only runtime path that turns computed Fields into materialized world data.
+ * Callers provide an already validated Actor/WIMP and declared write set; this
+ * function validates every address again and writes within the caller's SQLite
+ * transaction.
+ */
+export async function commitBoundaryActorFields(
+  sql: Database,
+  actorId: number,
+  wimp: string,
+  allowedFields: ReadonlySet<number>,
+  proposedFields: Record<string, unknown>,
+  owner: string,
+): Promise<BoundaryFieldCommit> {
+  const fields = new Map<number, unknown>()
+  for (const [address, value] of Object.entries(proposedFields)) {
+    const fieldId = resolveForceFieldId(address)
+    if (fieldId === null || !allowedFields.has(fieldId)) {
+      throw new Error(`${owner} cannot write field ${address}`)
+    }
+    if (JSON.stringify(value) === undefined) throw new Error(`Field ${address} result is not serializable`)
+    fields.set(fieldId, value)
+  }
+
+  const fieldRows = await sql<FieldRow[]>`
+    SELECT id, type FROM field WHERE wimp = ${wimp}
+  `
+  const fieldById = new Map(fieldRows.map((field) => [Number(field.id), field]))
+  const scalar: Record<string, unknown> = {}
+  const topology: Record<string, unknown> = {}
+
+  for (const [fieldId, value] of fields) {
+    const field = fieldById.get(fieldId)
+    if (!field) throw new Error(`Field ${fieldId} does not belong to actor ${actorId}`)
+    await sql`
+      INSERT INTO boundary_actor_field (actor, field, value_json)
+      VALUES (${actorId}, ${fieldId}, ${JSON.stringify(value)})
+      ON CONFLICT (actor, field) DO UPDATE SET value_json = excluded.value_json
+    `
+    const target = field.type === "enum" || field.type === "array" ? topology : scalar
+    target[String(fieldId)] = value
+  }
+
+  return {scalar, topology}
+}

--- a/energy/energy.ts
+++ b/energy/energy.ts
@@ -5,15 +5,18 @@ import type {EnergyHandlerDescriptor, EnergyProcessDescriptor} from "@metafor/ty
 import type {EnergyMassContext, EnergyMassStore} from "@metafor/types/energy/mass"
 import type {EnergyProtocol, EnergyProtocolOptions} from "@metafor/types/energy/protocol"
 import type {EnergyActionParams, PendingEnergyProcess} from "@metafor/types/energy/runtime"
-import type {
-  ProcessExecutionClaim,
-  ProcessExecutionGrant,
-  ProcessResultProposal,
-} from "@metafor/types/force/execution"
-import {isProcessExecutionId} from "@metafor/types/force/execution"
+import type {ProcessExecutionClaim, ProcessExecutionGrant, ProcessResultProposal} from "@metafor/types/force/execution"
 import type {ForceMessage} from "@metafor/types/force/message"
+import {
+  REACTION_CLAIM_KIND,
+  isReactionExecutionSignal,
+  type ReactionExecutionClaim,
+  type ReactionExecutionSignal,
+  type ReactionResultProposal,
+} from "@metafor/types/force/reaction"
 import {Force} from "force"
 import {EnergyCatalogStore} from "./catalog.ts"
+import {executeReaction} from "./reaction.ts"
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
@@ -179,28 +182,21 @@ export function startEnergyProtocol(options: EnergyProtocolOptions = {}): Energy
   const catalog = new EnergyCatalogStore()
   const pendingByActorId = new Map<number, PendingEnergyProcess>()
   const runningActorIds = new Set<number>()
+  const pendingReactions = new Map<string, ReactionExecutionSignal>()
+  const runningReactionIds = new Set<string>()
 
-  const emitResult = (
+  const emitReactionProposal = (
     part: "w+" | "w-",
-    pending: PendingEnergyProcess,
-    fields: Record<string, unknown>,
-    error?: string,
+    signal: ReactionExecutionSignal,
+    proposal: ReactionResultProposal,
   ): void => {
-    const proposal: ProcessResultProposal = {
-      processExecutionId: pending.processExecutionId,
-      processId: pending.processId,
-      fields,
-      ...(error === undefined ? {} : {error}),
-    }
-    force.impulse({
-      parts: [{
-        part,
-        op: "replace",
-        path: pending.actorId,
-        from: energyId,
-        value: proposal,
-      }],
-    })
+    force.impulse({parts: [{
+      part,
+      op: "replace",
+      path: signal.target.actorId,
+      from: energyId,
+      value: proposal,
+    }]})
   }
 
   force.onImpulse = (message: ForceMessage) => {
@@ -212,11 +208,7 @@ export function startEnergyProtocol(options: EnergyProtocolOptions = {}): Energy
         if (!pending) continue
         const actorWimp = catalog.actorWimp(actorId)
         const process = actorWimp && catalog.process(actorWimp, pending.state)
-        if (
-          !process ||
-          process.id !== pending.processId ||
-          process.descriptor !== pending.descriptor
-        ) pendingByActorId.delete(actorId)
+        if (!process || process.descriptor !== pending.descriptor) pendingByActorId.delete(actorId)
       }
       return
     }
@@ -225,7 +217,22 @@ export function startEnergyProtocol(options: EnergyProtocolOptions = {}): Energy
       case "photon": {
         if (part.op !== "test") break
         const actorId = parseActorIdPath(part.path)
-        if (actorId === null || typeof part.value !== "string" || !isProcessExecutionId(part.from)) break
+        if (actorId === null) break
+
+        if (isReactionExecutionSignal(part.value)) {
+          const signal = part.value
+          if (signal.target.actorId !== actorId || part.from !== signal.reactionExecutionId) break
+          pendingReactions.set(signal.reactionExecutionId, structuredClone(signal))
+          const claim: ReactionExecutionClaim = {
+            kind: REACTION_CLAIM_KIND,
+            energy: energyId,
+            reactionExecutionId: signal.reactionExecutionId,
+          }
+          force.impulse({parts: [{part: "z", op: "test", path: actorId, value: claim}]})
+          break
+        }
+
+        if (typeof part.value !== "string" || typeof part.from !== "string" || part.from.trim().length === 0) break
         const wimp = catalog.actorWimp(actorId)
         if (wimp === undefined) break
         const process = catalog.process(wimp, part.value)
@@ -236,61 +243,127 @@ export function startEnergyProtocol(options: EnergyProtocolOptions = {}): Energy
           actorId,
           wimp,
           state: part.value,
-          processId: process.id,
-          processExecutionId: part.from,
           descriptor,
+          processExecutionId: part.from,
+          processId: process.id,
         }
         pendingByActorId.set(actorId, pending)
-        const claim: ProcessExecutionClaim = {
-          energy: energyId,
-          processExecutionId: pending.processExecutionId,
-        }
-        force.impulse({
-          parts: [{
-            part: "z",
-            op: "test",
-            path: actorId,
-            value: claim,
-          }],
-        })
+        const claim: ProcessExecutionClaim = {energy: energyId, processExecutionId: part.from}
+        force.impulse({parts: [{part: "z", op: "test", path: actorId, value: claim}]})
         break
       }
+
       case "z": {
         if (part.op !== "copy") break
         const actorId = parseActorIdPath(part.path)
-        if (actorId === null || part.from !== energyId || !isRecord(part.value)) break
-        const grant = part.value as Partial<ProcessExecutionGrant>
-        if (!isProcessExecutionId(grant.processExecutionId) || !isRecord(grant.fields)) break
+        if (actorId === null || part.from !== energyId) break
+
+        if (isReactionExecutionSignal(part.value)) {
+          const signal = part.value
+          const pending = pendingReactions.get(signal.reactionExecutionId)
+          if (!pending || pending.target.actorId !== actorId || runningReactionIds.has(signal.reactionExecutionId)) break
+          runningReactionIds.add(signal.reactionExecutionId)
+          void executeReaction(signal, energyId, massStore)
+            .then((result) => {
+              if (!result.matched) {
+                emitReactionProposal("w-", signal, {
+                  reactionExecutionId: signal.reactionExecutionId,
+                  reactionId: signal.reactionId,
+                  matched: false,
+                  fields: {},
+                })
+                return
+              }
+              emitReactionProposal("w+", signal, {
+                reactionExecutionId: signal.reactionExecutionId,
+                reactionId: signal.reactionId,
+                matched: true,
+                fields: result.fields,
+              })
+            })
+            .catch((thrown) => {
+              emitReactionProposal("w-", signal, {
+                reactionExecutionId: signal.reactionExecutionId,
+                reactionId: signal.reactionId,
+                matched: false,
+                fields: {},
+                error: toError(thrown).message,
+              })
+            })
+            .finally(() => {
+              pendingReactions.delete(signal.reactionExecutionId)
+              runningReactionIds.delete(signal.reactionExecutionId)
+            })
+          break
+        }
+
+        if (!isRecord(part.value) || !isRecord(part.value.fields) || typeof part.value.processExecutionId !== "string") break
+        const grant = part.value as unknown as ProcessExecutionGrant
         if (runningActorIds.has(actorId)) break
         const pending = pendingByActorId.get(actorId)
-        if (!pending || grant.processExecutionId !== pending.processExecutionId) break
-        const processFields = grant.fields
+        if (!pending || pending.processExecutionId !== grant.processExecutionId) break
 
         runningActorIds.add(actorId)
-        void executeProcess(pending, energyId, processFields, massStore)
+        void executeProcess(pending, energyId, grant.fields, massStore)
           .then(async (data) => {
             if (pending.descriptor.type === "finally") {
-              emitResult("w+", pending, {})
+              const proposal: ProcessResultProposal = {
+                processExecutionId: pending.processExecutionId,
+                processId: pending.processId,
+                fields: {},
+              }
+              force.impulse({parts: [{part: "w+", op: "replace", path: actorId, from: energyId, value: proposal}]})
               return
             }
+            let fields: Record<string, unknown>
             try {
-              const fields = await executeProcessHandler(pending, pending.descriptor.success, processFields, {data})
-              emitResult("w+", pending, fields)
+              fields = await executeProcessHandler(pending, pending.descriptor.success, grant.fields, {data})
             } catch (error) {
-              emitResult("w-", pending, {}, toError(error).message)
+              const proposal: ProcessResultProposal = {
+                processExecutionId: pending.processExecutionId,
+                processId: pending.processId,
+                fields: {},
+                error: toError(error).message,
+              }
+              force.impulse({parts: [{part: "w-", op: "replace", path: actorId, from: energyId, value: proposal}]})
+              return
             }
+            const proposal: ProcessResultProposal = {
+              processExecutionId: pending.processExecutionId,
+              processId: pending.processId,
+              fields,
+            }
+            force.impulse({parts: [{part: "w+", op: "replace", path: actorId, from: energyId, value: proposal}]})
           })
           .catch(async (thrown) => {
             const actionError = toError(thrown)
             if (pending.descriptor.type === "finally") {
-              emitResult("w-", pending, {}, actionError.message)
+              const proposal: ProcessResultProposal = {
+                processExecutionId: pending.processExecutionId,
+                processId: pending.processId,
+                fields: {},
+                error: actionError.message,
+              }
+              force.impulse({parts: [{part: "w-", op: "replace", path: actorId, from: energyId, value: proposal}]})
               return
             }
             try {
-              const fields = await executeProcessHandler(pending, pending.descriptor.error, processFields, {error: actionError})
-              emitResult("w-", pending, fields, actionError.message)
+              const fields = await executeProcessHandler(pending, pending.descriptor.error, grant.fields, {error: actionError})
+              const proposal: ProcessResultProposal = {
+                processExecutionId: pending.processExecutionId,
+                processId: pending.processId,
+                fields,
+                error: actionError.message,
+              }
+              force.impulse({parts: [{part: "w-", op: "replace", path: actorId, from: energyId, value: proposal}]})
             } catch (handlerThrown) {
-              emitResult("w-", pending, {}, toError(handlerThrown).message)
+              const proposal: ProcessResultProposal = {
+                processExecutionId: pending.processExecutionId,
+                processId: pending.processId,
+                fields: {},
+                error: toError(handlerThrown).message,
+              }
+              force.impulse({parts: [{part: "w-", op: "replace", path: actorId, from: energyId, value: proposal}]})
             }
           })
           .finally(() => {
@@ -306,6 +379,8 @@ export function startEnergyProtocol(options: EnergyProtocolOptions = {}): Energy
     close() {
       pendingByActorId.clear()
       runningActorIds.clear()
+      pendingReactions.clear()
+      runningReactionIds.clear()
       if (ownsMassStore) massStore.clear?.()
       force.onImpulse = () => {}
     },

--- a/energy/reaction.spec.ts
+++ b/energy/reaction.spec.ts
@@ -1,0 +1,156 @@
+import {describe, expect, test} from "bun:test"
+import type {EnergyForce} from "@metafor/types/energy/protocol"
+import type {ForceMessage} from "@metafor/types/force/message"
+import {
+  REACTION_SIGNAL_KIND,
+  type ReactionExecutionSignal,
+  type ReactionResultProposal,
+} from "@metafor/types/force/reaction"
+import {startEnergyProtocol} from "./energy.ts"
+import {executeReaction, matchesCondition} from "./reaction.ts"
+
+const waitFor = async (predicate: () => boolean): Promise<void> => {
+  const deadline = Date.now() + 2_000
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for Reaction result")
+    await Bun.sleep(1)
+  }
+}
+
+const signal = (overrides: Partial<ReactionExecutionSignal> = {}): ReactionExecutionSignal => ({
+  kind: REACTION_SIGNAL_KIND,
+  reactionExecutionId: "reaction-execution",
+  reactionId: 701,
+  target: {actorId: 20, wimp: "target/meta", state: "idle"},
+  source: {
+    actorId: 10,
+    wimp: "source/meta",
+    timestamp: 1_700_000_000_000,
+    part: {op: "replace", path: "/context", value: {fields: {"1": 2}}},
+  },
+  value: {count: 1, result: 0},
+  writeFields: [[202, "result"]],
+  cond: "() => ({meta: 'source/meta', op: 'replace', path: '/context'})",
+  update: "({update, value, meta, atom, state}) => { if (meta !== 'source/meta' || atom !== '10' || state !== 'idle') throw new Error('bad source'); update({result: value.count + 1}) }",
+  ...overrides,
+})
+
+describe("Reaction condition evaluator", () => {
+  test("supports direct, string, numeric and collection operators", () => {
+    expect(matchesCondition("source/meta", {startsWith: "source", notInclude: "other"})).toBe(true)
+    expect(matchesCondition(10, {gte: 5, lt: 11, notEq: 9})).toBe(true)
+    expect(matchesCondition([1, 2], {include: 2, notInclude: 3, length: 2})).toBe(true)
+    expect(matchesCondition("abc", {pattern: /^a/, length: {min: 2, max: 4}})).toBe(true)
+    expect(matchesCondition({a: 1}, {a: 1})).toBe(true)
+  })
+
+  test("executes matched update with declared writes and persistent Mass", async () => {
+    const mass: Record<string, unknown> = {}
+    const result = await executeReaction(signal({
+      update: "({update, mass}) => { mass.runs = Number(mass.runs ?? 0) + 1; update({result: mass.runs, ignored: 9}) }",
+    }), "energy-test", {get: () => mass})
+    expect(result).toEqual({matched: true, fields: {"202": 1}})
+    expect(mass).toEqual({runs: 1})
+
+    const skipped = await executeReaction(signal({
+      cond: "() => ({meta: 'different/meta'})",
+    }), "energy-test", {get: () => mass})
+    expect(skipped).toEqual({matched: false, fields: {}})
+  })
+})
+
+describe("Energy Reaction claim protocol", () => {
+  const harness = () => {
+    const messages: ForceMessage[] = []
+    const force: EnergyForce = {
+      onImpulse: () => {},
+      impulse(message) {
+        messages.push(structuredClone(message))
+      },
+    }
+    const protocol = startEnergyProtocol({force, energyId: "energy-reaction", runtimeKind: "server"})
+    return {
+      messages,
+      emit(message: ForceMessage) {
+        void force.onImpulse(structuredClone(message))
+      },
+      close() {
+        protocol.close()
+      },
+    }
+  }
+
+  test("claims, executes and returns identified W+ proposal", async () => {
+    const runtime = harness()
+    const current = signal()
+    try {
+      runtime.emit({parts: [{
+        part: "photon",
+        op: "test",
+        path: current.target.actorId,
+        from: current.reactionExecutionId,
+        value: current,
+      }]})
+      await waitFor(() => runtime.messages.some((item) => item.parts[0]?.part === "z"))
+      expect(runtime.messages[0]?.parts[0]).toEqual({
+        part: "z",
+        op: "test",
+        path: current.target.actorId,
+        value: {
+          kind: "reaction-claim",
+          energy: "energy-reaction",
+          reactionExecutionId: current.reactionExecutionId,
+        },
+      })
+
+      runtime.emit({parts: [{
+        part: "z",
+        op: "copy",
+        path: current.target.actorId,
+        from: "energy-reaction",
+        value: current,
+      }]})
+      await waitFor(() => runtime.messages.some((item) => item.parts[0]?.part === "w+"))
+      const proposal = runtime.messages.find((item) => item.parts[0]?.part === "w+")?.parts[0]
+      expect(proposal).toEqual({
+        part: "w+",
+        op: "replace",
+        path: current.target.actorId,
+        from: "energy-reaction",
+        value: {
+          reactionExecutionId: current.reactionExecutionId,
+          reactionId: current.reactionId,
+          matched: true,
+          fields: {"202": 2},
+        } satisfies ReactionResultProposal,
+      })
+    } finally {
+      runtime.close()
+    }
+  })
+
+  test("returns an explicit skipped W- when filter does not match", async () => {
+    const runtime = harness()
+    const current = signal({cond: "() => ({meta: 'other/meta'})"})
+    try {
+      runtime.emit({parts: [{
+        part: "photon",
+        op: "test",
+        path: current.target.actorId,
+        from: current.reactionExecutionId,
+        value: current,
+      }]})
+      await waitFor(() => runtime.messages.some((item) => item.parts[0]?.part === "z"))
+      runtime.emit({parts: [{part: "z", op: "copy", path: current.target.actorId, from: "energy-reaction", value: current}]})
+      await waitFor(() => runtime.messages.some((item) => item.parts[0]?.part === "w-"))
+      expect(runtime.messages.find((item) => item.parts[0]?.part === "w-")?.parts[0]?.value).toEqual({
+        reactionExecutionId: current.reactionExecutionId,
+        reactionId: current.reactionId,
+        matched: false,
+        fields: {},
+      })
+    } finally {
+      runtime.close()
+    }
+  })
+})

--- a/energy/reaction.ts
+++ b/energy/reaction.ts
@@ -1,0 +1,160 @@
+import type {EnergyMassStore} from "@metafor/types/energy/mass"
+import type {ReactionExecutionSignal} from "@metafor/types/force/reaction"
+
+type JsonRecord = Record<string, unknown>
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const deepEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) return true
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return Array.isArray(left) && Array.isArray(right) && left.length === right.length &&
+      left.every((value, index) => deepEqual(value, right[index]))
+  }
+  if (!isRecord(left) || !isRecord(right)) return false
+  const keys = Object.keys(left)
+  return keys.length === Object.keys(right).length && keys.every((key) => key in right && deepEqual(left[key], right[key]))
+}
+
+const lengthOf = (value: unknown): number | null =>
+  typeof value === "string" || Array.isArray(value) ? value.length : isRecord(value) ? Object.keys(value).length : null
+
+const includes = (actual: unknown, expected: unknown): boolean => {
+  if (typeof actual === "string") return actual.includes(String(expected))
+  if (Array.isArray(actual)) return actual.some((item) => deepEqual(item, expected))
+  return false
+}
+
+const matchesOperator = (actual: unknown, operator: string, expected: unknown): boolean => {
+  switch (operator) {
+    case "eq": return deepEqual(actual, expected)
+    case "notEq":
+    case "neq": return !deepEqual(actual, expected)
+    case "gt": return Number(actual) > Number(expected)
+    case "gte": return Number(actual) >= Number(expected)
+    case "lt": return Number(actual) < Number(expected)
+    case "lte": return Number(actual) <= Number(expected)
+    case "notGt": return !(Number(actual) > Number(expected))
+    case "notGte": return !(Number(actual) >= Number(expected))
+    case "notLt": return !(Number(actual) < Number(expected))
+    case "notLte": return !(Number(actual) <= Number(expected))
+    case "startsWith": return typeof actual === "string" && actual.startsWith(String(expected))
+    case "endsWith": return typeof actual === "string" && actual.endsWith(String(expected))
+    case "notStartsWith": return typeof actual === "string" && !actual.startsWith(String(expected))
+    case "notEndsWith": return typeof actual === "string" && !actual.endsWith(String(expected))
+    case "include": return includes(actual, expected)
+    case "notInclude": return !includes(actual, expected)
+    case "pattern": return expected instanceof RegExp && typeof actual === "string" && expected.test(actual)
+    case "in": return Array.isArray(expected) && expected.some((item) => deepEqual(item, actual))
+    case "notIn": return Array.isArray(expected) && !expected.some((item) => deepEqual(item, actual))
+    case "between": {
+      if (!Array.isArray(expected) || expected.length !== 2) return false
+      return (actual as never) >= (expected[0] as never) && (actual as never) <= (expected[1] as never)
+    }
+    case "length": {
+      const length = lengthOf(actual)
+      if (length === null) return false
+      if (typeof expected === "number") return length === expected
+      if (!isRecord(expected)) return false
+      return (expected.min === undefined || length >= Number(expected.min)) &&
+        (expected.max === undefined || length <= Number(expected.max))
+    }
+    case "isEmpty": {
+      const length = lengthOf(actual)
+      const empty = actual === null || actual === undefined || length === 0
+      return empty === Boolean(expected)
+    }
+    case "null": return (actual === null) === Boolean(expected)
+    case "every": return Array.isArray(actual) && actual.every((item) => matchesCondition(item, expected))
+    case "some": return Array.isArray(actual) && actual.some((item) => matchesCondition(item, expected))
+    default: return false
+  }
+}
+
+export const matchesCondition = (actual: unknown, condition: unknown): boolean => {
+  if (condition instanceof RegExp) return typeof actual === "string" && condition.test(actual)
+  if (!isRecord(condition)) return deepEqual(actual, condition)
+
+  const operators = Object.entries(condition)
+  const known = new Set([
+    "eq", "notEq", "neq", "gt", "gte", "lt", "lte", "notGt", "notGte", "notLt", "notLte",
+    "startsWith", "endsWith", "notStartsWith", "notEndsWith", "include", "notInclude", "pattern",
+    "in", "notIn", "between", "length", "isEmpty", "null", "every", "some",
+  ])
+  if (!operators.every(([operator]) => known.has(operator))) return deepEqual(actual, condition)
+  return operators.every(([operator, expected]) => matchesOperator(actual, operator, expected))
+}
+
+const evaluateFilter = (signal: ReactionExecutionSignal): boolean => {
+  const fn = (0, eval)(`(${signal.cond})`)
+  if (typeof fn !== "function") throw new Error(`Reaction ${signal.reactionId} filter is not a function`)
+  const conditions = fn({
+    self: {
+      atom: String(signal.target.actorId),
+      meta: signal.target.wimp,
+      path: String(signal.target.actorId),
+    },
+    value: structuredClone(signal.value),
+  }) as unknown
+  if (!isRecord(conditions)) throw new Error(`Reaction ${signal.reactionId} filter did not return conditions`)
+
+  const actual: JsonRecord = {
+    meta: signal.source.wimp,
+    atom: String(signal.source.actorId),
+    timestamp: signal.source.timestamp,
+    op: signal.source.part.op,
+    path: signal.source.part.path,
+    value: signal.source.part.value,
+  }
+  return Object.entries(conditions).every(([key, condition]) => matchesCondition(actual[key], condition))
+}
+
+export type ReactionExecutionResult = {
+  matched: boolean
+  fields: Record<string, unknown>
+}
+
+export async function executeReaction(
+  signal: ReactionExecutionSignal,
+  energyId: string,
+  massStore: EnergyMassStore,
+): Promise<ReactionExecutionResult> {
+  if (!evaluateFilter(signal)) return {matched: false, fields: {}}
+
+  const fieldIdByKey = new Map(signal.writeFields.map(([fieldId, key]) => [key, String(fieldId)]))
+  const fields: Record<string, unknown> = {}
+  const update = (values: unknown): Record<string, unknown> => {
+    if (!isRecord(values)) return fields
+    for (const [key, value] of Object.entries(values)) {
+      const fieldId = fieldIdByKey.get(key)
+      if (fieldId !== undefined) fields[fieldId] = value
+    }
+    return fields
+  }
+
+  const mass = massStore.get({
+    energyId,
+    actorId: signal.target.actorId,
+    wimp: signal.target.wimp,
+    state: signal.target.state,
+  })
+  const fn = (0, eval)(`(${signal.update})`)
+  if (typeof fn !== "function") throw new Error(`Reaction ${signal.reactionId} update is not a function`)
+  await fn({
+    update,
+    value: structuredClone(signal.value),
+    mass,
+    meta: signal.source.wimp,
+    atom: String(signal.source.actorId),
+    timestamp: signal.source.timestamp,
+    part: structuredClone(signal.source.part),
+    state: signal.target.state,
+    self: {
+      atom: String(signal.target.actorId),
+      meta: signal.target.wimp,
+      path: String(signal.target.actorId),
+    },
+  })
+  return {matched: true, fields}
+}

--- a/fixture/runtime-universe.spec.ts
+++ b/fixture/runtime-universe.spec.ts
@@ -11,31 +11,29 @@ import type {
 } from "@metafor/types/force/execution"
 import type {ForceMessage} from "@metafor/types/force/message"
 import type {Particle} from "@metafor/types/force/particle"
+import type {
+  ReactionExecutionClaim,
+  ReactionExecutionSignal,
+  ReactionResultCommit,
+  ReactionResultProposal,
+} from "@metafor/types/force/reaction"
 import {boundaryEntityId} from "../boundary/incremental.ts"
 
 const ROOT = "test/runtime-universe"
+const TARGET = "test/runtime-reaction-target"
 const repositoryRoot = resolve(import.meta.dir, "..")
 const inheritedEnv = Object.fromEntries(
   Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
 )
 
-type ProcessLine = {
-  stream: "stdout" | "stderr"
-  text: string
-}
-
+type ProcessLine = {stream: "stdout" | "stderr"; text: string}
 type ManagedProcess = {
   name: string
   process: ReturnType<typeof Bun.spawn>
   lines: ProcessLine[]
-  waitForLine(
-    predicate: (line: string) => boolean,
-    fromIndex?: number,
-    timeoutMs?: number,
-  ): Promise<{lineIndex: number; line: string}>
+  waitForLine(predicate: (line: string) => boolean, fromIndex?: number, timeoutMs?: number): Promise<{lineIndex: number; line: string}>
   stop(): Promise<void>
 }
-
 type ForceEvent = {
   lineIndex: number
   source: string
@@ -52,7 +50,6 @@ const consumeLines = async (
   const reader = stream.getReader()
   const decoder = new TextDecoder()
   let pending = ""
-
   while (true) {
     const {done, value} = await reader.read()
     if (value) pending += decoder.decode(value, {stream: !done})
@@ -65,17 +62,12 @@ const consumeLines = async (
     }
     if (done) break
   }
-
   pending += decoder.decode()
   const text = pending.replace(/\r$/, "")
   if (text.length > 0) lines.push({stream: channel, text})
 }
 
-const spawnManaged = (
-  name: string,
-  entry: string,
-  env: Record<string, string>,
-): ManagedProcess => {
+const spawnManaged = (name: string, entry: string, env: Record<string, string>): ManagedProcess => {
   const lines: ProcessLine[] = []
   const subprocess = Bun.spawn({
     cmd: ["bun", entry],
@@ -85,7 +77,6 @@ const spawnManaged = (
     stdout: "pipe",
     stderr: "pipe",
   })
-
   void consumeLines(subprocess.stdout as ReadableStream<Uint8Array>, "stdout", lines)
   void consumeLines(subprocess.stderr as ReadableStream<Uint8Array>, "stderr", lines)
 
@@ -93,7 +84,7 @@ const spawnManaged = (
     name,
     process: subprocess,
     lines,
-    async waitForLine(predicate, fromIndex = 0, timeoutMs = 15_000) {
+    async waitForLine(predicate, fromIndex = 0, timeoutMs = 20_000) {
       const deadline = Date.now() + timeoutMs
       while (Date.now() < deadline) {
         for (let lineIndex = fromIndex; lineIndex < lines.length; lineIndex++) {
@@ -101,11 +92,11 @@ const spawnManaged = (
           if (predicate(line)) return {lineIndex, line}
         }
         if (subprocess.exitCode !== null) {
-          throw new Error(`${name} exited with ${subprocess.exitCode}:\n${lines.slice(-30).map((item) => item.text).join("\n")}`)
+          throw new Error(`${name} exited with ${subprocess.exitCode}:\n${lines.slice(-40).map((item) => item.text).join("\n")}`)
         }
         await Bun.sleep(20)
       }
-      throw new Error(`Timed out waiting for ${name} output:\n${lines.slice(-30).map((item) => item.text).join("\n")}`)
+      throw new Error(`Timed out waiting for ${name} output:\n${lines.slice(-40).map((item) => item.text).join("\n")}`)
     },
     async stop() {
       if (subprocess.exitCode !== null) return
@@ -122,13 +113,7 @@ const parseForceEvent = (line: string, lineIndex: number): ForceEvent | null => 
   try {
     const message = JSON.parse(match[3]!) as ForceMessage
     if (!Array.isArray(message.parts) || message.parts.length !== 1) return null
-    return {
-      lineIndex,
-      source: match[1]!,
-      direction: match[2]! as "<-" | "->",
-      message,
-      line,
-    }
+    return {lineIndex, source: match[1]!, direction: match[2]! as "<-" | "->", message, line}
   } catch {
     return null
   }
@@ -138,7 +123,7 @@ const waitForForceEvent = async (
   force: ManagedProcess,
   predicate: (event: ForceEvent) => boolean,
   fromIndex = 0,
-  timeoutMs = 20_000,
+  timeoutMs = 30_000,
 ): Promise<ForceEvent> => {
   const result = await force.waitForLine((line) => {
     const lineIndex = force.lines.findIndex((item) => item.text === line)
@@ -151,6 +136,11 @@ const waitForForceEvent = async (
 }
 
 const particle = (event: ForceEvent): Particle => event.message.parts[0]!
+const actorWimp = (event: ForceEvent): string | undefined => {
+  const value = particle(event).value as {actor?: {wimp?: unknown}} | undefined
+  return typeof value?.actor?.wimp === "string" ? value.actor.wimp : undefined
+}
+const actorIdFromEvent = (event: ForceEvent): number => Number(String(particle(event).path).split("/").at(-1))
 
 const postImpulse = async (baseUrl: string, part: Particle): Promise<void> => {
   const response = await fetch(`${baseUrl}/force`, {
@@ -170,51 +160,30 @@ const eventLabel = (event: ForceEvent): string => {
 }
 
 describe("minimal MetaFor runtime universe", () => {
-  test("commits Energy result through Boundary without Bulk or product shells", async () => {
+  test("runs Process and Reaction through canonical Boundary commits", async () => {
     const temporary = mkdtempSync(join(tmpdir(), "metafor-runtime-universe-"))
     const database = join(temporary, "boundary.sqlite")
     const processes: ManagedProcess[] = []
 
     try {
-      const force = spawnManaged("force", "force/server.ts", {
-        PORT: "0",
-        METAFOR_LOG_IMPULSES: "full",
-      })
+      const force = spawnManaged("force", "force/server.ts", {PORT: "0", METAFOR_LOG_IMPULSES: "full"})
       processes.push(force)
       const listening = await force.waitForLine((line) => line.includes("[force] listening on "))
       const port = /:(\d+)\/?$/.exec(listening.line)?.[1]
       if (!port) throw new Error(`Cannot parse Force port from: ${listening.line}`)
       const forceAddress = `ws://127.0.0.1:${port}/ws`
       const forceHttp = `http://127.0.0.1:${port}`
-      const domainEnv = {
-        FORCE_ADDRESS: forceAddress,
-        FORCE_RECONNECT: "0",
-        METAFOR_LOG_IMPULSES: "off",
-        PORT: "0",
-      }
+      const domainEnv = {FORCE_ADDRESS: forceAddress, FORCE_RECONNECT: "0", METAFOR_LOG_IMPULSES: "off", PORT: "0"}
 
-      const boundary = spawnManaged("boundary", "boundary/server.ts", {
-        ...domainEnv,
-        BOUNDARY_PATH: database,
-      })
+      const boundary = spawnManaged("boundary", "boundary/server.ts", {...domainEnv, BOUNDARY_PATH: database})
       processes.push(boundary)
       await force.waitForLine((line) => line.includes("[force] connected: boundary boundary-local"))
-
-      const matrix = spawnManaged("matrix", "matrix/server.ts", {
-        ...domainEnv,
-        METAFOR_WEAK_BACKEND: "cpu",
-      })
+      const matrix = spawnManaged("matrix", "matrix/server.ts", {...domainEnv, METAFOR_WEAK_BACKEND: "cpu"})
       processes.push(matrix)
       await force.waitForLine((line) => line.includes("[force] connected: matrix matrix-local"))
-
-      const energy = spawnManaged("energy", "energy/server.ts", {
-        ...domainEnv,
-        ENERGY_ID: "energy-universe",
-        ENERGY_RUNTIME_KIND: "server",
-      })
+      const energy = spawnManaged("energy", "energy/server.ts", {...domainEnv, ENERGY_ID: "energy-universe", ENERGY_RUNTIME_KIND: "server"})
       processes.push(energy)
       await force.waitForLine((line) => line.includes("[force] connected: energy energy-local"))
-
       const dark = spawnManaged("dark", "dark/server.ts", domainEnv)
       processes.push(dark)
       await force.waitForLine((line) => line.includes("[force] connected: dark dark-local"))
@@ -222,143 +191,163 @@ describe("minimal MetaFor runtime universe", () => {
       const activationStart = force.lines.length
       await postImpulse(forceHttp, {part: "inflaton", op: "test", path: ROOT})
 
-      const darkMeta = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:dark" && particle(event).part === "inflaton" &&
-          particle(event).op === "add" && particle(event).path === `${ROOT}/meta`,
-        activationStart,
-      )
-      const boundaryProcess = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:boundary" && particle(event).part === "graviton" &&
-          particle(event).path === `declaration/${ROOT}/processes/1`,
-        darkMeta.lineIndex + 1,
-      )
-      const boundaryActor = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:boundary" && particle(event).part === "graviton" &&
-          particle(event).op === "add" && typeof particle(event).path === "string" &&
-          String(particle(event).path).startsWith("actor/"),
-        darkMeta.lineIndex + 1,
-      )
-      const bootstrap = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:boundary" && particle(event).part === "graviton" &&
-          particle(event).op === "replace" && particle(event).path === "runtime/matrix",
-        Math.max(boundaryProcess.lineIndex, boundaryActor.lineIndex) + 1,
-      )
-      const idle = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:matrix" && particle(event).part === "photon" &&
-          particle(event).op === "replace" && particle(event).value === "idle",
-        bootstrap.lineIndex + 1,
-      )
+      const darkMeta = await waitForForceEvent(force, (event) =>
+        event.source === "force:dark" && particle(event).part === "inflaton" &&
+        particle(event).op === "add" && particle(event).path === `${ROOT}/meta`, activationStart)
+      const boundaryProcess = await waitForForceEvent(force, (event) =>
+        event.source === "force:boundary" && particle(event).part === "graviton" &&
+        particle(event).path === `declaration/${ROOT}/processes/1`, darkMeta.lineIndex + 1)
+      const boundaryReaction = await waitForForceEvent(force, (event) =>
+        event.source === "force:boundary" && particle(event).part === "graviton" &&
+        particle(event).path === `declaration/${TARGET}/reactions/1`, darkMeta.lineIndex + 1)
+      const sourceActorEvent = await waitForForceEvent(force, (event) =>
+        event.source === "force:boundary" && particle(event).part === "graviton" &&
+        particle(event).op === "add" && actorWimp(event) === ROOT, darkMeta.lineIndex + 1)
+      const targetActorEvent = await waitForForceEvent(force, (event) =>
+        event.source === "force:boundary" && particle(event).part === "graviton" &&
+        particle(event).op === "add" && actorWimp(event) === TARGET, darkMeta.lineIndex + 1)
+      const sourceActorId = actorIdFromEvent(sourceActorEvent)
+      const targetActorId = actorIdFromEvent(targetActorEvent)
 
-      const actorId = Number(particle(idle).path)
-      expect(Number.isSafeInteger(actorId) && actorId > 0).toBe(true)
-      expect(particle(boundaryActor).path).toBe(`actor/${actorId}`)
+      const bootstrap = await waitForForceEvent(force, (event) =>
+        event.source === "force:boundary" && particle(event).part === "graviton" &&
+        particle(event).op === "replace" && particle(event).path === "runtime/matrix",
+        Math.max(boundaryProcess.lineIndex, boundaryReaction.lineIndex, sourceActorEvent.lineIndex, targetActorEvent.lineIndex) + 1)
+      const sourceIdle = await waitForForceEvent(force, (event) =>
+        event.source === "force:matrix" && particle(event).part === "photon" &&
+        particle(event).op === "replace" && particle(event).path === sourceActorId && particle(event).value === "idle",
+        bootstrap.lineIndex + 1)
+      const targetIdle = await waitForForceEvent(force, (event) =>
+        event.source === "force:matrix" && particle(event).part === "photon" &&
+        particle(event).op === "replace" && particle(event).path === targetActorId && particle(event).value === "idle",
+        bootstrap.lineIndex + 1)
 
       const inputFieldId = boundaryEntityId(`${ROOT}/fields/1`)
       const outputFieldId = boundaryEntityId(`${ROOT}/fields/2`)
       const processId = boundaryEntityId(`${ROOT}/processes/1`)
+      const targetFieldId = boundaryEntityId(`${TARGET}/fields/1`)
+      const reactionId = boundaryEntityId(`${TARGET}/reactions/1`)
+
       const inputStart = force.lines.length
-      await postImpulse(forceHttp, {
-        part: "gluon",
-        op: "replace",
-        path: actorId,
-        value: {fields: {[String(inputFieldId)]: 1}},
-      })
-
-      const input = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:http" && particle(event).part === "gluon" &&
-          particle(event).path === actorId,
-        inputStart,
-      )
-      const ready = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:matrix" && particle(event).part === "photon" &&
-          particle(event).op === "test" && particle(event).path === actorId && particle(event).value === "ready",
-        input.lineIndex + 1,
-      )
-      expect(typeof particle(ready).from).toBe("string")
+      await postImpulse(forceHttp, {part: "gluon", op: "replace", path: sourceActorId, value: {fields: {[String(inputFieldId)]: 1}}})
+      const input = await waitForForceEvent(force, (event) =>
+        event.source === "force:http" && particle(event).part === "gluon" && particle(event).path === sourceActorId, inputStart)
+      const ready = await waitForForceEvent(force, (event) =>
+        event.source === "force:matrix" && particle(event).part === "photon" &&
+        particle(event).op === "test" && particle(event).path === sourceActorId && particle(event).value === "ready",
+        input.lineIndex + 1)
       const processExecutionId = String(particle(ready).from)
+      expect(processExecutionId.length).toBeGreaterThan(0)
 
-      const claim = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:energy" && particle(event).part === "z" &&
-          particle(event).op === "test" && particle(event).path === actorId,
-        ready.lineIndex + 1,
-      )
-      const claimValue = particle(claim).value as ProcessExecutionClaim
-      expect(claimValue).toEqual({energy: "energy-universe", processExecutionId})
-
-      const copy = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:matrix" && particle(event).part === "z" &&
-          particle(event).op === "copy" && particle(event).path === actorId,
-        claim.lineIndex + 1,
-      )
-      const grant = particle(copy).value as ProcessExecutionGrant
-      expect(particle(copy).from).toBe("energy-universe")
-      expect(grant).toEqual({
+      const processClaim = await waitForForceEvent(force, (event) => {
+        const value = particle(event).value as Partial<ProcessExecutionClaim> | undefined
+        return event.source === "force:energy" && particle(event).part === "z" &&
+          value?.processExecutionId === processExecutionId
+      }, ready.lineIndex + 1)
+      expect(particle(processClaim).value).toEqual({energy: "energy-universe", processExecutionId})
+      const processGrant = await waitForForceEvent(force, (event) => {
+        const value = particle(event).value as Partial<ProcessExecutionGrant> | undefined
+        return event.source === "force:matrix" && particle(event).part === "z" &&
+          particle(event).op === "copy" && value?.processExecutionId === processExecutionId
+      }, processClaim.lineIndex + 1)
+      expect(particle(processGrant).value).toEqual({
         processExecutionId,
-        fields: {
-          [String(inputFieldId)]: 1,
-          [String(outputFieldId)]: 0,
-        },
+        fields: {[String(inputFieldId)]: 1, [String(outputFieldId)]: 0},
       })
 
-      const proposal = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:energy" && particle(event).part === "w+" &&
-          particle(event).op === "replace" && particle(event).path === actorId,
-        copy.lineIndex + 1,
-      )
-      expect(particle(proposal).from).toBe("energy-universe")
-      expect(particle(proposal).value as ProcessResultProposal).toEqual({
+      const processProposal = await waitForForceEvent(force, (event) => {
+        const value = particle(event).value as Partial<ProcessResultProposal> | undefined
+        return event.source === "force:energy" && particle(event).part === "w+" &&
+          value?.processExecutionId === processExecutionId
+      }, processGrant.lineIndex + 1)
+      expect(particle(processProposal).value).toEqual({
         processExecutionId,
         processId,
         fields: {[String(outputFieldId)]: 2},
       })
+      const sourceCommit = await waitForForceEvent(force, (event) =>
+        event.source === "force:boundary" && particle(event).part === "gluon" &&
+        particle(event).path === sourceActorId && particle(event).from === processExecutionId,
+        processProposal.lineIndex + 1)
+      const processAck = await waitForForceEvent(force, (event) => {
+        const value = particle(event).value as Partial<ProcessResultCommit> | undefined
+        return event.source === "force:boundary" && particle(event).part === "w+" &&
+          value?.processExecutionId === processExecutionId
+      }, sourceCommit.lineIndex + 1)
+      const complete = await waitForForceEvent(force, (event) =>
+        event.source === "force:matrix" && particle(event).part === "photon" &&
+        particle(event).path === sourceActorId && particle(event).value === "complete",
+        processAck.lineIndex + 1)
 
-      const committedField = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:boundary" && particle(event).part === "gluon" &&
-          particle(event).op === "replace" && particle(event).path === actorId &&
-          particle(event).from === processExecutionId,
-        proposal.lineIndex + 1,
-      )
-      expect(particle(committedField).value).toEqual({fields: {[String(outputFieldId)]: 2}})
+      const reactionSignalEvent = await waitForForceEvent(force, (event) => {
+        const value = particle(event).value as Partial<ReactionExecutionSignal> | undefined
+        return event.source === "force:boundary" && particle(event).part === "photon" &&
+          value?.kind === "reaction" && value.reactionId === reactionId && particle(event).path === targetActorId
+      }, sourceCommit.lineIndex + 1)
+      const reactionSignal = particle(reactionSignalEvent).value as ReactionExecutionSignal
+      expect(reactionSignal.target).toEqual({actorId: targetActorId, wimp: TARGET, state: "idle"})
+      expect(reactionSignal.source.actorId).toBe(sourceActorId)
 
-      const acknowledgement = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:boundary" && particle(event).part === "w+" &&
-          particle(event).op === "copy" && particle(event).path === actorId &&
-          particle(event).from === processExecutionId,
-        committedField.lineIndex + 1,
-      )
-      expect(particle(acknowledgement).value as ProcessResultCommit).toEqual({
-        processExecutionId,
-        processId,
-        energy: "energy-universe",
+      const reactionClaim = await waitForForceEvent(force, (event) => {
+        const value = particle(event).value as Partial<ReactionExecutionClaim> | undefined
+        return event.source === "force:energy" && particle(event).part === "z" &&
+          value?.kind === "reaction-claim" && value.reactionExecutionId === reactionSignal.reactionExecutionId
+      }, reactionSignalEvent.lineIndex + 1)
+      const reactionGrant = await waitForForceEvent(force, (event) => {
+        const value = particle(event).value as Partial<ReactionExecutionSignal> | undefined
+        return event.source === "force:boundary" && particle(event).part === "z" &&
+          particle(event).op === "copy" && value?.reactionExecutionId === reactionSignal.reactionExecutionId
+      }, reactionClaim.lineIndex + 1)
+      const reactionProposal = await waitForForceEvent(force, (event) => {
+        const value = particle(event).value as Partial<ReactionResultProposal> | undefined
+        return event.source === "force:energy" && particle(event).part === "w+" &&
+          value?.reactionExecutionId === reactionSignal.reactionExecutionId
+      }, reactionGrant.lineIndex + 1)
+      expect(particle(reactionProposal).value).toEqual({
+        reactionExecutionId: reactionSignal.reactionExecutionId,
+        reactionId,
+        matched: true,
+        fields: {[String(targetFieldId)]: 2},
       })
-
-      const complete = await waitForForceEvent(
-        force,
-        (event) => event.source === "force:matrix" && particle(event).part === "photon" &&
-          particle(event).op === "replace" && particle(event).path === actorId && particle(event).value === "complete",
-        acknowledgement.lineIndex + 1,
-      )
+      const targetCommit = await waitForForceEvent(force, (event) =>
+        event.source === "force:boundary" && particle(event).part === "gluon" &&
+        particle(event).path === targetActorId && particle(event).from === reactionSignal.reactionExecutionId,
+        reactionProposal.lineIndex + 1)
+      const reactionAck = await waitForForceEvent(force, (event) => {
+        const value = particle(event).value as Partial<ReactionResultCommit> | undefined
+        return event.source === "force:boundary" && particle(event).part === "w+" &&
+          value?.reactionExecutionId === reactionSignal.reactionExecutionId
+      }, targetCommit.lineIndex + 1)
+      expect(particle(reactionAck).value).toEqual({
+        reactionExecutionId: reactionSignal.reactionExecutionId,
+        reactionId,
+        energy: "energy-universe",
+        status: "committed",
+      })
 
       const inspection = new SQL(`sqlite://${database}`)
       try {
-        const row = (await inspection<Array<{valueJson: string}>>`
-          SELECT value_json AS valueJson
+        const values = await inspection<Array<{actor: number; field: number; valueJson: string}>>`
+          SELECT actor, field, value_json AS valueJson
             FROM boundary_actor_field
-           WHERE actor = ${actorId} AND field = ${outputFieldId}
-        `)[0]
-        expect(row && JSON.parse(row.valueJson)).toBe(2)
+           WHERE (actor = ${sourceActorId} AND field = ${outputFieldId})
+              OR (actor = ${targetActorId} AND field = ${targetFieldId})
+           ORDER BY actor
+        `
+        expect(values.map((row) => [Number(row.actor), Number(row.field), JSON.parse(row.valueJson)])).toEqual([
+          [sourceActorId, outputFieldId, 2],
+          [targetActorId, targetFieldId, 2],
+        ])
+        const states = await inspection<Array<{actor: number; name: string}>>`
+          SELECT actor_state.actor AS actor, state.name AS name
+            FROM actor_state JOIN state ON state.id = actor_state.metaState
+           WHERE actor_state.actor IN (${sourceActorId}, ${targetActorId})
+           ORDER BY actor_state.actor
+        `
+        expect(states.map((row) => [Number(row.actor), row.name])).toEqual([
+          [sourceActorId, "complete"],
+          [targetActorId, "idle"],
+        ])
       } finally {
         await inspection.close()
       }
@@ -366,30 +355,43 @@ describe("minimal MetaFor runtime universe", () => {
       expect(force.lines.some((item) => item.text.includes("[force] connected: bulk "))).toBe(false)
       expect(force.lines.some((item) => item.text.includes("[force] connected: interpreter "))).toBe(false)
 
-      expect(boundaryActor.lineIndex).toBeGreaterThan(darkMeta.lineIndex)
-      expect(boundaryProcess.lineIndex).toBeGreaterThan(darkMeta.lineIndex)
-      expect(bootstrap.lineIndex).toBeGreaterThan(Math.max(boundaryActor.lineIndex, boundaryProcess.lineIndex))
-      const runtimeTrace = [
+      const ordered = [
         bootstrap,
-        idle,
         input,
         ready,
-        claim,
-        copy,
-        proposal,
-        committedField,
-        acknowledgement,
-        complete,
+        processClaim,
+        processGrant,
+        processProposal,
+        sourceCommit,
+        processAck,
+        reactionSignalEvent,
+        reactionClaim,
+        reactionGrant,
+        reactionProposal,
+        targetCommit,
+        reactionAck,
       ]
-      for (let index = 1; index < runtimeTrace.length; index++) {
-        expect(runtimeTrace[index]!.lineIndex).toBeGreaterThan(runtimeTrace[index - 1]!.lineIndex)
+      for (let index = 1; index < ordered.length; index++) {
+        expect(ordered[index]!.lineIndex).toBeGreaterThan(ordered[index - 1]!.lineIndex)
       }
-      const trace = [darkMeta, boundaryActor, boundaryProcess, ...runtimeTrace]
-        .sort((left, right) => left.lineIndex - right.lineIndex)
+      expect(sourceIdle.lineIndex).toBeGreaterThan(bootstrap.lineIndex)
+      expect(targetIdle.lineIndex).toBeGreaterThan(bootstrap.lineIndex)
+      expect(complete.lineIndex).toBeGreaterThan(processAck.lineIndex)
+      const trace = [
+        darkMeta,
+        boundaryProcess,
+        boundaryReaction,
+        sourceActorEvent,
+        targetActorEvent,
+        sourceIdle,
+        targetIdle,
+        ...ordered,
+        complete,
+      ].sort((left, right) => left.lineIndex - right.lineIndex)
       console.log(`[runtime-universe]\n${trace.map(eventLabel).join("\n")}`)
     } finally {
       for (const managed of processes.toReversed()) await managed.stop()
       rmSync(temporary, {recursive: true, force: true})
     }
-  }, 60_000)
+  }, 90_000)
 })

--- a/github/test/runtime-reaction-target/meta.ts
+++ b/github/test/runtime-reaction-target/meta.ts
@@ -1,0 +1,23 @@
+import type {MetaDSL} from "@metafor/types/metafor/schema"
+
+const meta = {
+  name: "Runtime Reaction Target",
+  desc: "Observes a committed source context change through Energy Reaction",
+  fields: [
+    {key: "observed", type: "number", required: true, default: 0},
+  ],
+  superposition: [
+    {name: "idle"},
+  ],
+  reactions: [{
+    key: "observe-source",
+    label: "Observe source commit",
+    cond: "() => ({meta: 'test/runtime-universe', op: 'replace', path: '/context'})",
+    src: "({update}) => update({observed: 2})",
+    read: ["observed"],
+    write: ["observed"],
+    states: ["idle"],
+  }],
+} satisfies MetaDSL
+
+export default meta

--- a/github/test/runtime-universe/meta.ts
+++ b/github/test/runtime-universe/meta.ts
@@ -1,9 +1,6 @@
 import type {MetaDSL} from "@metafor/types/metafor/schema"
 
-/**
- * Neutral integration universe for the first observable core lifecycle.
- * It intentionally has no Matter children, Bulk, browser or provider binding.
- */
+/** Neutral source Actor for the observable Process → Reaction lifecycle. */
 const meta = {
   name: "Runtime Universe",
   desc: "input=0 → input=1 → Energy process → output=2 → complete",
@@ -32,6 +29,7 @@ const meta = {
       },
     },
   }],
+  matter: [{kind: "wimp", src: "test/runtime-reaction-target"}],
 } satisfies MetaDSL
 
 export default meta

--- a/types/force/reaction.ts
+++ b/types/force/reaction.ts
@@ -40,6 +40,7 @@ export type ReactionExecutionClaim = {
 export type ReactionResultProposal = {
   reactionExecutionId: string
   reactionId: number
+  matched: boolean
   fields: Record<string, unknown>
   error?: string
 }
@@ -48,6 +49,7 @@ export type ReactionResultCommit = {
   reactionExecutionId: string
   reactionId: number
   energy: string
+  status: "committed" | "skipped" | "failed"
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -77,5 +79,5 @@ export const isReactionExecutionClaim = (value: unknown): value is ReactionExecu
 
 export const isReactionResultProposal = (value: unknown): value is ReactionResultProposal =>
   isRecord(value) && isReactionExecutionId(value.reactionExecutionId) &&
-  positiveId(value.reactionId) && isRecord(value.fields) &&
-  (value.error === undefined || typeof value.error === "string")
+  positiveId(value.reactionId) && typeof value.matched === "boolean" &&
+  isRecord(value.fields) && (value.error === undefined || typeof value.error === "string")

--- a/types/force/reaction.ts
+++ b/types/force/reaction.ts
@@ -1,0 +1,81 @@
+import type {ParticleOperation} from "./particle.ts"
+
+export const REACTION_SIGNAL_KIND = "reaction" as const
+export const REACTION_CLAIM_KIND = "reaction-claim" as const
+
+export type ReactionEventPart = {
+  op: ParticleOperation
+  path: string
+  value?: unknown
+  from?: string | number
+}
+
+export type ReactionExecutionSignal = {
+  kind: typeof REACTION_SIGNAL_KIND
+  reactionExecutionId: string
+  reactionId: number
+  target: {
+    actorId: number
+    wimp: string
+    state: string
+  }
+  source: {
+    actorId: number
+    wimp: string
+    timestamp: number
+    part: ReactionEventPart
+  }
+  value: Record<string, unknown>
+  writeFields: Array<[fieldId: number, key: string]>
+  cond: string
+  update: string
+}
+
+export type ReactionExecutionClaim = {
+  kind: typeof REACTION_CLAIM_KIND
+  energy: string
+  reactionExecutionId: string
+}
+
+export type ReactionResultProposal = {
+  reactionExecutionId: string
+  reactionId: number
+  fields: Record<string, unknown>
+  error?: string
+}
+
+export type ReactionResultCommit = {
+  reactionExecutionId: string
+  reactionId: number
+  energy: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const positiveId = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value > 0
+
+export const isReactionExecutionId = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+export const isReactionExecutionSignal = (value: unknown): value is ReactionExecutionSignal => {
+  if (!isRecord(value) || value.kind !== REACTION_SIGNAL_KIND) return false
+  if (!isReactionExecutionId(value.reactionExecutionId) || !positiveId(value.reactionId)) return false
+  if (!isRecord(value.target) || !positiveId(value.target.actorId) || typeof value.target.wimp !== "string" || typeof value.target.state !== "string") return false
+  if (!isRecord(value.source) || !positiveId(value.source.actorId) || typeof value.source.wimp !== "string" || typeof value.source.timestamp !== "number" || !isRecord(value.source.part)) return false
+  if (!isRecord(value.value) || !Array.isArray(value.writeFields) || typeof value.cond !== "string" || typeof value.update !== "string") return false
+  return value.writeFields.every((item) =>
+    Array.isArray(item) && item.length === 2 && positiveId(item[0]) && typeof item[1] === "string",
+  )
+}
+
+export const isReactionExecutionClaim = (value: unknown): value is ReactionExecutionClaim =>
+  isRecord(value) && value.kind === REACTION_CLAIM_KIND &&
+  typeof value.energy === "string" && value.energy.trim().length > 0 &&
+  isReactionExecutionId(value.reactionExecutionId)
+
+export const isReactionResultProposal = (value: unknown): value is ReactionResultProposal =>
+  isRecord(value) && isReactionExecutionId(value.reactionExecutionId) &&
+  positiveId(value.reactionId) && isRecord(value.fields) &&
+  (value.error === undefined || typeof value.error === "string")

--- a/types/package.json
+++ b/types/package.json
@@ -16,6 +16,7 @@
     "./force/replay": "./force/replay.ts",
     "./force/fields": "./force/fields.ts",
     "./force/execution": "./force/execution.ts",
+    "./force/reaction": "./force/reaction.ts",
     "./boundary/actor": "./boundary/actor.ts",
     "./boundary/value": "./boundary/value.ts",
     "./boundary/topology": "./boundary/topology.ts",


### PR DESCRIPTION
## Результат

Завершён следующий причинный слой после canonical Process W-result: Reaction проходит через тот же Boundary-owned world transaction path, без второго evaluator и отдельного mutation API.

## Полный контур

```text
Boundary committed Gluon/Higgs
→ active Reaction candidate
→ Reaction Photon + reactionExecutionId
→ Energy Z claim
→ Boundary frozen grant
→ Energy filter/update
→ W proposal
→ Boundary declared-write validation
→ atomic world commit
→ Gluon/Higgs consequences
→ W/copy acknowledgment
```

## Реализовано

- canonical Actor State в Boundary;
- relational State materialization из incremental declarations;
- supersede устаревших Process/Reaction executions при смене State;
- общий `boundary/world.ts` writer для Process и Reaction;
- Reaction execution store и causal identity;
- исполнение filter/update в Energy;
- explicit skipped/failed/committed outcomes;
- защита declared write set, Field ownership и stale State;
- multi-process universe с Source и Reaction Target.

## Подтверждённые исправления

1. Incremental State declarations раньше не попадали в relational `state`; Photon корректно отвергался как неизвестный. State projection теперь синхронизируется транзакционно.
2. `boundary/server.ts` раньше принимал любой `z/test` за replay и поглощал Reaction claim. Replay-ветка теперь активируется только для реального `force/replay/...`; actor-addressed Reaction claim проходит в materialization.

## Проверки

```text
Core causal tests                     success
CPU Weak suite                        success
TypeScript typecheck                  success
WebGPU parity on Vulkan adapter       success
```

Проверены Boundary State, Process commit, Reaction commit/skip/failure, Energy Reaction execution, CPU/WebGPU Matrix parity и полный universe:

```text
Dark
→ Boundary
→ Matrix
→ Process Energy
→ Boundary commit
→ Reaction Energy
→ Boundary commit
```

Bulk и product shells не участвуют; Interpreter, AGENT rules и root TODO не возвращаются.