### PR TITLE
Запускать ядро MetaFor одной командой

### DIFF
--- a/.github/workflows/core-runtime.yml
+++ b/.github/workflows/core-runtime.yml
@@ -13,6 +13,7 @@ on:
       - "boundary/**"
       - "matrix/**"
       - "energy/**"
+      - "runtime/**"
       - "fixture/**"
       - "github/**"
   push:
@@ -27,6 +28,7 @@ on:
       - "boundary/**"
       - "matrix/**"
       - "energy/**"
+      - "runtime/**"
       - "fixture/**"
       - "github/**"
   workflow_dispatch:
@@ -81,6 +83,7 @@ jobs:
               matrix/runtime.parity.spec.ts \
               energy/energy.spec.ts \
               energy/reaction.spec.ts \
+              runtime/start.spec.ts \
               fixture/runtime-universe.spec.ts
             do
               echo "::group::$test_file"

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Meta / DSL
 → Matrix gravity → strong → weak
 → Photon
 → Energy Z claim/copy
-→ W result
+→ W proposal
 → Boundary canonical commit
-→ derived consequences
+→ Gluon/Higgs consequences
 → Reaction
 → Bulk
 ```
@@ -57,22 +57,28 @@ Boundary может передать Matrix производную `runtime/matr
 
 ## Текущий статус
 
-Уже подтверждено GitHub Actions:
+GitHub Actions подтверждает:
 
 - CPU и WebGPU исполняют одинаковые State/lock/Photon traces;
 - WebGPU compute реально работает через Vulkan software adapter;
-- минимальный universe проходит `Dark → Boundary → Matrix → Energy` без Bulk;
-- structured logs восстанавливают порядок Inflaton, Graviton, Gluon, Photon, Z и W;
-- Matrix не принимает сырой результат Energy как canonical world truth.
+- внешний Field input сначала коммитится Boundary и только затем достигает Matrix;
+- Process result становится world truth только после Boundary validation и commit;
+- Reaction исполняется Energy и использует тот же canonical world writer;
+- минимальный universe проходит полный путь `Input → Process → Reaction` без Bulk;
+- structured logs восстанавливают порядок Inflaton, Graviton, Gluon, Higgs,
+  Photon, Z и W.
 
-Текущая реализационная задача — завершить атомарный контракт:
+Рабочий non-visual контур уже замкнут:
 
 ```text
-W proposal
-→ Boundary validation and commit
-→ Gluon/Higgs consequences
-→ Matrix unlock and re-evaluation
-→ Reaction
+external Input
+→ Boundary
+→ Matrix
+→ Process / Energy
+→ Boundary
+→ Reaction / Energy
+→ Boundary
+→ Matrix
 ```
 
 ## Быстрый запуск
@@ -83,7 +89,23 @@ W proposal
 bun install
 ```
 
-Минимальный runtime без Bulk:
+Одна команда поднимает Force, Boundary, Dark, Matrix и Energy, ждёт health и
+регистрацию доменов, затем активирует `METAFOR_ROOT`:
+
+```bash
+bun start
+```
+
+По умолчанию активируется нейтральная Meta `test/runtime-universe`. Другой корень
+и постоянная Boundary database задаются окружением:
+
+```bash
+METAFOR_ROOT=owner/project \
+BOUNDARY_PATH=./data/boundary.sqlite \
+bun start
+```
+
+Эквивалентная команда:
 
 ```bash
 bun run runtime
@@ -102,9 +124,25 @@ bun run runtime:cpu
 bun run runtime:gpu
 ```
 
-Минимальный сквозной тест:
+`runtime:gpu` является строгим режимом: отсутствие WebGPU завершает запуск
+ошибкой. `auto` предпочитает WebGPU и использует CPU только как fallback.
+
+Для запуска доменов без автоматической активации Meta:
 
 ```bash
+METAFOR_AUTO_ACTIVATE=0 bun run runtime
+```
+
+Либо без launcher lifecycle:
+
+```bash
+bun run runtime:domains
+```
+
+Проверка one-command launch и полного universe:
+
+```bash
+bun run test:runtime-launch
 bun run test:runtime-universe
 ```
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,18 +1,18 @@
 # Разработка MetaFor
 
-Этот документ описывает только активное ядро и его воспроизводимую проверку.
-Исторические product shells не участвуют в сборке и запуске.
+Этот документ описывает только активное ядро и его воспроизводимый запуск.
+Исторические product shells не участвуют в сборке и runtime.
 
 ## Домены
 
-| Domain   | Port | Entry                |
-| -------- | ---- | -------------------- |
-| Force    | 4000 | `force/server.ts`    |
-| Boundary | 4001 | `boundary/server.ts` |
-| Dark     | 4002 | `dark/server.ts`     |
-| Matrix   | 4003 | `matrix/server.ts`   |
-| Bulk     | 4004 | `bulk/server.ts`     |
-| Energy   | 4005 | `energy/server.ts`   |
+| Domain   | Default port | Entry                |
+| -------- | ------------ | -------------------- |
+| Force    | 4000         | `force/server.ts`    |
+| Boundary | 4001         | `boundary/server.ts` |
+| Dark     | 4002         | `dark/server.ts`     |
+| Matrix   | 4003         | `matrix/server.ts`   |
+| Bulk     | 4004         | `bulk/server.ts`     |
+| Energy   | 4005         | `energy/server.ts`   |
 
 Основной причинный контур:
 
@@ -24,42 +24,132 @@ Matrix → Photon
 Energy ↔ Z claim/copy
 Energy → W proposal
 Boundary → canonical commit → Gluon/Higgs → W acknowledgment
+Boundary consequence → Reaction → Energy → Boundary
 ```
 
-Boundary является единственной канонической materialized persistence. Matrix,
+Boundary является единственной canonical materialized persistence. Matrix,
 Energy и Bulk не читают Boundary SQLite напрямую.
 
-## Запуск
+## One-command launcher
 
-Минимальный runtime без Bulk:
+Основной запуск:
+
+```bash
+bun start
+```
+
+или:
 
 ```bash
 bun run runtime
 ```
 
-С полными Impulse logs:
+`runtime/start.ts` выполняет последовательность:
 
-```bash
-bun run runtime:logs
+1. запускает Force;
+2. ждёт Force health;
+3. запускает Boundary, Matrix, Energy и Dark;
+4. ждёт health каждого домена;
+5. ждёт их регистрации в Force;
+6. отправляет `inflaton/test` для `METAFOR_ROOT`;
+7. оставляет runtime работающим до `SIGINT` или `SIGTERM`;
+8. завершает дочерние процессы в обратном порядке.
+
+Launcher не является новым доменом и не владеет world state. Это минимальный
+операционный lifecycle существующих доменов.
+
+### Настройки
+
+```text
+METAFOR_ROOT            default: test/runtime-universe
+BOUNDARY_PATH            default: boundary/tmp/runtime.sqlite
+METAFOR_AUTO_ACTIVATE    default: 1; 0 отключает activation
+METAFOR_WEAK_BACKEND     auto | cpu | gpu
+METAFOR_FORCE_PORT       default: 4000
+METAFOR_BOUNDARY_PORT    default: 4001
+METAFOR_DARK_PORT        default: 4002
+METAFOR_MATRIX_PORT      default: 4003
+METAFOR_ENERGY_PORT      default: 4005
 ```
 
-Backend Matrix:
+Пример:
+
+```bash
+METAFOR_ROOT=owner/project \
+BOUNDARY_PATH=./data/boundary.sqlite \
+METAFOR_LOG_IMPULSES=full \
+bun start
+```
+
+`runtime:gpu` является строгим режимом и завершается ошибкой без WebGPU:
 
 ```bash
 bun run runtime:cpu
 bun run runtime:gpu
 ```
 
-`runtime:gpu` является строгим режимом и завершается ошибкой без WebGPU. Default
-режим `auto` предпочитает WebGPU и использует CPU только как fallback.
+Для ручного запуска доменов без launcher lifecycle:
 
-Полный контур с Bulk:
+```bash
+bun run runtime:domains
+```
+
+Полный контур с Bulk остаётся отдельной командой:
 
 ```bash
 bun run force
 ```
 
-## Загрузка Meta
+## Force health
+
+`GET /health` Force возвращает зарегистрированные clients:
+
+```json
+{
+  "ok": true,
+  "domain": "force",
+  "clients": [
+    {"domain": "boundary", "id": "boundary-local"},
+    {"domain": "dark", "id": "dark-local"},
+    {"domain": "energy", "id": "energy-local"},
+    {"domain": "matrix", "id": "matrix-local"}
+  ]
+}
+```
+
+Launcher использует это как registration barrier. Фиксированный `sleep` не
+считается доказательством готовности.
+
+## Canonical external input
+
+Uncommitted external `Gluon/Higgs` без `from` Force направляет только Boundary.
+Matrix не видит mutation до commit.
+
+```text
+external Field mutation
+→ Force boundary-only routing
+→ Boundary validation and atomic commit
+→ boundary:* Gluon/Higgs consequence
+→ Matrix Weak
+```
+
+Если Boundary недоступен, HTTP `/force` возвращает `503`, а input не
+рассылается другим доменам.
+
+Пример после materialization нужного Actor:
+
+```bash
+curl -sS -X POST http://127.0.0.1:4000/force \
+  -H 'content-type: application/json' \
+  -d '{"parts":[{"part":"gluon","op":"replace","path":1,"value":{"fields":{"101":1}}}]}'
+```
+
+Actor и Field IDs являются адресами materialized мира; production-клиент должен
+получать их из общей среды, а не угадывать.
+
+## Ручная загрузка Meta
+
+При `METAFOR_AUTO_ACTIVATE=0`:
 
 ```bash
 curl -sS -X POST http://127.0.0.1:4000/force \
@@ -73,13 +163,14 @@ curl -sS -X POST http://127.0.0.1:4000/force \
 2. Boundary коммитит declaration и materialization.
 3. Boundary выпускает Actor/Process consequences и `runtime/matrix` bootstrap.
 4. Matrix строит packed `gravity/strong/weak` и выпускает начальный Photon.
-5. Gluon/Higgs обновляют packed heap.
+5. External Field mutation проходит canonical Boundary path.
 6. Process-bound State выпускает Photon с `processExecutionId`.
 7. Energy claim-ит Process через Z и получает frozen fields.
 8. Energy возвращает W proposal.
 9. Boundary валидирует execution identity и declared write set.
-10. Только после atomic commit Boundary выпускает field consequences и W acknowledgment.
+10. Только после atomic commit Boundary выпускает consequences и W acknowledgment.
 11. Matrix снимает lock и повторно выполняет Weak.
+12. Активные Reaction проходят через Energy и тот же canonical world writer.
 
 ## Наблюдаемость
 
@@ -102,14 +193,19 @@ METAFOR_LOG_PARTS=inflaton,graviton,gluon,higgs,photon,z,w+,w-
 ## Проверка
 
 ```bash
+bun run test:runtime-launch
 bun run test:runtime-universe
 bun test boundary/runtime/matrix.spec.ts
+bun test boundary/input.spec.ts
+bun test boundary/execution.spec.ts
+bun test boundary/reaction.spec.ts
 bun test matrix/matrix.spec.ts
 bun test matrix/runtime.parity.spec.ts
 bun test matrix/weak/tests/weak.cpu.test.ts
 bun test matrix/weak/tests/weak.gpu.test.ts
 bun test matrix/weak/tests/weak.parity.test.ts
 bun test energy/energy.spec.ts
+bun test energy/reaction.spec.ts
 bun run tsc --noEmit
 ```
 
@@ -123,5 +219,8 @@ Production domains общаются только через Force. Сквозн�
 processes и временную Boundary database. Test-only чтение SQLite допустимо только
 для assertions и не становится runtime API.
 
-Исторический код до очистки сохранён в ветке
-`archive/pre-core-split-2026-07-11`.
+Исторический код до очистки сохранён в ветке:
+
+```text
+archive/pre-core-split-2026-07-11
+```

--- a/force/server.ts
+++ b/force/server.ts
@@ -59,7 +59,13 @@ export const server = Bun.serve<{domain?: string; id?: string}>({
   routes: {
     "/health": {
       GET() {
-        return Response.json({ok: true, domain: "force"})
+        return Response.json({
+          ok: true,
+          domain: "force",
+          clients: [...clients.values()]
+            .map((client) => ({...client}))
+            .sort((left, right) => left.domain.localeCompare(right.domain) || left.id.localeCompare(right.id)),
+        })
       },
     },
     "/force": {

--- a/package.json
+++ b/package.json
@@ -46,11 +46,14 @@
     "typescript": "^6.0.2"
   },
   "scripts": {
-    "runtime": "bun run --parallel --filter force --filter boundary --filter dark --filter matrix --filter energy server",
+    "start": "bun runtime/start.ts",
+    "runtime": "bun runtime/start.ts",
+    "runtime:domains": "bun run --parallel --filter force --filter boundary --filter dark --filter matrix --filter energy server",
     "runtime:logs": "METAFOR_LOG_IMPULSES=full bun run runtime",
     "runtime:cpu": "METAFOR_WEAK_BACKEND=cpu bun run runtime",
     "runtime:gpu": "METAFOR_WEAK_BACKEND=gpu bun run runtime",
     "force": "bun run --parallel --filter force --filter boundary --filter dark --filter matrix --filter bulk --filter energy server",
+    "test:runtime-launch": "bun test runtime/start.spec.ts",
     "test:runtime-universe": "bun test fixture/runtime-universe.spec.ts",
     "test:all": "bun test",
     "clear": "rm -rf node_modules && bun run --parallel --filter '*' clear",

--- a/runtime/start.spec.ts
+++ b/runtime/start.spec.ts
@@ -1,0 +1,129 @@
+import {describe, expect, test} from "bun:test"
+import {existsSync, mkdtempSync, rmSync} from "node:fs"
+import {tmpdir} from "node:os"
+import {join, resolve} from "node:path"
+
+const repositoryRoot = resolve(import.meta.dir, "..")
+const inheritedEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+)
+
+type CapturedLine = {
+  stream: "stdout" | "stderr"
+  text: string
+}
+
+const capture = async (
+  stream: ReadableStream<Uint8Array>,
+  channel: CapturedLine["stream"],
+  lines: CapturedLine[],
+): Promise<void> => {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let pending = ""
+  while (true) {
+    const {done, value} = await reader.read()
+    if (value) pending += decoder.decode(value, {stream: !done})
+    let newline = pending.indexOf("\n")
+    while (newline !== -1) {
+      const text = pending.slice(0, newline).replace(/\r$/, "")
+      pending = pending.slice(newline + 1)
+      if (text) lines.push({stream: channel, text})
+      newline = pending.indexOf("\n")
+    }
+    if (done) break
+  }
+  pending += decoder.decode()
+  if (pending) lines.push({stream: channel, text: pending.replace(/\r$/, "")})
+}
+
+const reservePorts = (): number[] => {
+  const probes = Array.from({length: 5}, () => Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response("probe"),
+  }))
+  const ports = probes.map((probe) => Number(new URL(probe.url).port))
+  for (const probe of probes) probe.stop(true)
+  return ports
+}
+
+const waitForLine = async (
+  process: ReturnType<typeof Bun.spawn>,
+  lines: CapturedLine[],
+  predicate: (line: string) => boolean,
+  timeoutMs = 20_000,
+): Promise<string> => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const found = lines.find((line) => predicate(line.text))
+    if (found) return found.text
+    if (process.exitCode !== null) {
+      throw new Error(`Runtime exited with ${process.exitCode}:\n${lines.slice(-40).map((line) => line.text).join("\n")}`)
+    }
+    await Bun.sleep(20)
+  }
+  throw new Error(`Timed out waiting for runtime output:\n${lines.slice(-40).map((line) => line.text).join("\n")}`)
+}
+
+describe("MetaFor runtime launcher", () => {
+  test("starts, registers and activates the core universe without Bulk", async () => {
+    const temporary = mkdtempSync(join(tmpdir(), "metafor-runtime-launch-"))
+    const database = join(temporary, "boundary.sqlite")
+    const [force, boundary, dark, matrix, energy] = reservePorts()
+    const lines: CapturedLine[] = []
+    const runtime = Bun.spawn({
+      cmd: [process.execPath, "runtime/start.ts"],
+      cwd: repositoryRoot,
+      env: {
+        ...inheritedEnv,
+        METAFOR_FORCE_PORT: String(force),
+        METAFOR_BOUNDARY_PORT: String(boundary),
+        METAFOR_DARK_PORT: String(dark),
+        METAFOR_MATRIX_PORT: String(matrix),
+        METAFOR_ENERGY_PORT: String(energy),
+        METAFOR_ROOT: "test/runtime-universe",
+        METAFOR_WEAK_BACKEND: "cpu",
+        METAFOR_LOG_IMPULSES: "full",
+        BOUNDARY_PATH: database,
+      },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    void capture(runtime.stdout as ReadableStream<Uint8Array>, "stdout", lines)
+    void capture(runtime.stderr as ReadableStream<Uint8Array>, "stderr", lines)
+
+    try {
+      await waitForLine(runtime, lines, (line) => line === "[metafor] activated root=test/runtime-universe")
+      await waitForLine(runtime, lines, (line) => line.startsWith("[metafor] running "))
+      await waitForLine(runtime, lines, (line) => line.includes('"part":"photon"') && line.includes('"value":"idle"'))
+
+      const response = await fetch(`http://127.0.0.1:${force}/health`)
+      expect(response.status).toBe(200)
+      const health = await response.json() as {
+        ok: boolean
+        domain: string
+        clients: Array<{domain: string; id: string}>
+      }
+      expect(health.ok).toBe(true)
+      expect(health.domain).toBe("force")
+      expect(new Set(health.clients.map((client) => client.domain))).toEqual(
+        new Set(["boundary", "dark", "energy", "matrix"]),
+      )
+      expect(existsSync(database)).toBe(true)
+      expect(lines.some((line) => line.text.includes("[force] connected: bulk "))).toBe(false)
+      expect(lines.some((line) => line.text.includes("interpreter"))).toBe(false)
+    } finally {
+      if (runtime.exitCode === null) runtime.kill("SIGTERM")
+      const code = await Promise.race([
+        runtime.exited,
+        Bun.sleep(5_000).then(() => null),
+      ])
+      if (code === null && runtime.exitCode === null) runtime.kill("SIGKILL")
+      rmSync(temporary, {recursive: true, force: true})
+    }
+
+    expect(runtime.exitCode).toBe(0)
+  }, 60_000)
+})

--- a/runtime/start.ts
+++ b/runtime/start.ts
@@ -1,0 +1,187 @@
+import {resolve} from "node:path"
+
+type DomainName = "force" | "boundary" | "dark" | "matrix" | "energy"
+
+type RuntimeChild = {
+  domain: DomainName
+  process: ReturnType<typeof Bun.spawn>
+}
+
+type ForceHealth = {
+  ok: boolean
+  domain: "force"
+  clients: Array<{domain: string; id: string}>
+}
+
+const repositoryRoot = resolve(import.meta.dir, "..")
+const inheritedEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+)
+
+const readPort = (name: string, fallback: number): number => {
+  const raw = Bun.env[name]?.trim()
+  if (!raw) return fallback
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value < 1 || value > 65_535) {
+    throw new Error(`${name} must be an integer between 1 and 65535`)
+  }
+  return value
+}
+
+const ports = {
+  force: readPort("METAFOR_FORCE_PORT", 4000),
+  boundary: readPort("METAFOR_BOUNDARY_PORT", 4001),
+  dark: readPort("METAFOR_DARK_PORT", 4002),
+  matrix: readPort("METAFOR_MATRIX_PORT", 4003),
+  energy: readPort("METAFOR_ENERGY_PORT", 4005),
+} as const
+
+const forceHttp = `http://127.0.0.1:${ports.force}`
+const forceAddress = `ws://127.0.0.1:${ports.force}/ws`
+const root = Bun.env.METAFOR_ROOT?.trim() || "test/runtime-universe"
+const autoActivate = Bun.env.METAFOR_AUTO_ACTIVATE?.trim() !== "0"
+const children: RuntimeChild[] = []
+let stopping = false
+
+const spawnDomain = (
+  domain: DomainName,
+  entry: string,
+  port: number,
+  extraEnv: Record<string, string> = {},
+): RuntimeChild => {
+  const child: RuntimeChild = {
+    domain,
+    process: Bun.spawn({
+      cmd: [process.execPath, entry],
+      cwd: repositoryRoot,
+      env: {
+        ...inheritedEnv,
+        PORT: String(port),
+        FORCE_ADDRESS: forceAddress,
+        FORCE_RECONNECT: "1",
+        ...extraEnv,
+      },
+      stdin: "ignore",
+      stdout: "inherit",
+      stderr: "inherit",
+    }),
+  }
+  children.push(child)
+  return child
+}
+
+const waitForHealth = async (domain: DomainName, port: number, timeoutMs = 15_000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs
+  const url = `http://127.0.0.1:${port}/health`
+  while (Date.now() < deadline) {
+    const child = children.find((candidate) => candidate.domain === domain)
+    if (child?.process.exitCode !== null) {
+      throw new Error(`${domain} exited before becoming healthy: ${child.process.exitCode}`)
+    }
+    try {
+      const response = await fetch(url)
+      if (response.ok) {
+        const health = await response.json() as {ok?: unknown; domain?: unknown}
+        if (health.ok === true && health.domain === domain) return
+      }
+    } catch {
+      // The domain is still starting.
+    }
+    await Bun.sleep(25)
+  }
+  throw new Error(`Timed out waiting for ${domain} health at ${url}`)
+}
+
+const waitForForceClients = async (timeoutMs = 15_000): Promise<void> => {
+  const expected = new Set<DomainName>(["boundary", "dark", "matrix", "energy"])
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${forceHttp}/health`)
+      if (response.ok) {
+        const health = await response.json() as ForceHealth
+        const connected = new Set(health.clients.map((client) => client.domain))
+        if ([...expected].every((domain) => connected.has(domain))) return
+      }
+    } catch {
+      // Force or one of its clients is still starting.
+    }
+    await Bun.sleep(25)
+  }
+  throw new Error(`Timed out waiting for core domains to register with Force at ${forceAddress}`)
+}
+
+const activateRoot = async (): Promise<void> => {
+  const response = await fetch(`${forceHttp}/force`, {
+    method: "POST",
+    headers: {"content-type": "application/json"},
+    body: JSON.stringify({
+      parts: [{part: "inflaton", op: "test", path: root}],
+    }),
+  })
+  if (!response.ok) throw new Error(`Meta activation failed: ${response.status} ${await response.text()}`)
+  const result = await response.json() as {ok?: unknown}
+  if (result.ok !== true) throw new Error(`Meta activation was not accepted: ${JSON.stringify(result)}`)
+}
+
+const shutdown = async (): Promise<void> => {
+  if (stopping) return
+  stopping = true
+  for (const child of children.toReversed()) {
+    if (child.process.exitCode === null) child.process.kill("SIGTERM")
+  }
+  await Promise.race([
+    Promise.all(children.map((child) => child.process.exited)),
+    Bun.sleep(2_000),
+  ])
+  for (const child of children.toReversed()) {
+    if (child.process.exitCode === null) child.process.kill("SIGKILL")
+  }
+}
+
+const run = async (): Promise<void> => {
+  const boundaryPath = Bun.env.BOUNDARY_PATH?.trim() || resolve(repositoryRoot, "boundary", "tmp", "runtime.sqlite")
+
+  spawnDomain("force", "force/server.ts", ports.force)
+  await waitForHealth("force", ports.force)
+
+  spawnDomain("boundary", "boundary/server.ts", ports.boundary, {BOUNDARY_PATH: boundaryPath})
+  spawnDomain("matrix", "matrix/server.ts", ports.matrix)
+  spawnDomain("energy", "energy/server.ts", ports.energy)
+  spawnDomain("dark", "dark/server.ts", ports.dark)
+
+  await Promise.all([
+    waitForHealth("boundary", ports.boundary),
+    waitForHealth("matrix", ports.matrix),
+    waitForHealth("energy", ports.energy),
+    waitForHealth("dark", ports.dark),
+  ])
+  await waitForForceClients()
+
+  if (autoActivate) {
+    await activateRoot()
+    console.log(`[metafor] activated root=${root}`)
+  }
+  console.log(`[metafor] running force=${forceHttp} boundary=${boundaryPath} backend=${Bun.env.METAFOR_WEAK_BACKEND?.trim() || "auto"}`)
+
+  const signal = new Promise<{kind: "signal"; signal: string}>((resolveSignal) => {
+    process.once("SIGINT", () => resolveSignal({kind: "signal", signal: "SIGINT"}))
+    process.once("SIGTERM", () => resolveSignal({kind: "signal", signal: "SIGTERM"}))
+  })
+  const exit = Promise.race(children.map((child) =>
+    child.process.exited.then((code) => ({kind: "exit" as const, domain: child.domain, code})),
+  ))
+  const outcome = await Promise.race([signal, exit])
+  if (outcome.kind === "exit" && !stopping) {
+    throw new Error(`${outcome.domain} exited unexpectedly with code ${outcome.code}`)
+  }
+}
+
+try {
+  await run()
+} catch (error) {
+  console.error(`[metafor] ${error instanceof Error ? error.message : String(error)}`)
+  process.exitCode = 1
+} finally {
+  await shutdown()
+}


### PR DESCRIPTION
## Цель

Перевести рабочий non-visual core из набора вручную запускаемых серверов в один воспроизводимый runtime lifecycle без Interpreter и Bulk.

## Новый запуск

```bash
bun start
# или
bun run runtime
```

Launcher:

1. запускает Force;
2. ждёт Force health;
3. запускает Boundary, Matrix, Energy и Dark;
4. ждёт health каждого домена;
5. ждёт их фактической регистрации в Force;
6. активирует `METAFOR_ROOT` через `inflaton/test`;
7. оставляет runtime работать до SIGINT/SIGTERM;
8. корректно завершает дочерние процессы.

Default root — `test/runtime-universe`, default Boundary database — `boundary/tmp/runtime.sqlite`.

## Операционные настройки

- `METAFOR_ROOT`;
- `BOUNDARY_PATH`;
- `METAFOR_AUTO_ACTIVATE=0` для ручной загрузки;
- `METAFOR_WEAK_BACKEND=auto|cpu|gpu`;
- отдельные `METAFOR_*_PORT` для всех core-доменов.

Старый raw parallel start сохранён как `bun run runtime:domains`.

## Force readiness

`GET /health` Force теперь возвращает зарегистрированные `{domain,id}`. Launcher использует это как настоящий registration barrier и не заменяет готовность фиксированным sleep.

## Проверка

Добавлен multi-process `runtime/start.spec.ts`, который:

- резервирует отдельные порты;
- запускает launcher как subprocess;
- ждёт регистрацию core-доменов;
- ждёт activation нейтральной Meta и initial Photon;
- проверяет persistent Boundary file;
- подтверждает отсутствие Bulk и Interpreter;
- завершает runtime через SIGTERM и ожидает clean exit.

Тест включён в read-only Core Runtime Verification. PR остаётся draft до зелёных CPU causal tests, typecheck и WebGPU parity.